### PR TITLE
Fixes/db environments

### DIFF
--- a/LBHFSSPublicAPI.Tests/Properties/launchSettings.json
+++ b/LBHFSSPublicAPI.Tests/Properties/launchSettings.json
@@ -15,12 +15,12 @@
       "launchUrl": "api/v1/healthcheck/ping",
       "applicationUrl": "http://localhost:5000",
       "ConnectionStrings": {
-        "DefaultConnection": "host=test-database;port=5432;username=postgres;password=mypassword;database=testdb"
+        "DefaultConnection": "host=test-database;port=6543;username=postgres;password=mypassword;database=testdb"
       },
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_ENVIRONMENT": "Test",
         "DB_HOST": "test-database",
-        "DB_PORT": "5432",
+        "DB_PORT": "6543",
         "DB_USERNAME": "postgres",
         "DB_PASSWORD": "mypassword",
         "DB_DATABASE": "testdb"

--- a/LBHFSSPublicAPI/Startup.cs
+++ b/LBHFSSPublicAPI/Startup.cs
@@ -137,9 +137,14 @@ namespace LBHFSSPublicAPI
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public static void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            env.EnvironmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                using (var scope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                {
+                    scope.ServiceProvider.GetService<DatabaseContext>().Database.Migrate();
+                }
             }
             else
             {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 3000:3000
     environment:
       - CONNECTION_STRING=Host=dev-database;Port=5432;Database=testdb;Username=postgres;Password=mypassword
+      - ASPNETCORE_ENVIRONMENT=Development
     links:
       - dev-database
   dev-database:
@@ -30,6 +31,7 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword
       - DB_DATABASE=testdb
+      - ASPNETCORE_ENVIRONMENT=Test
     links:
       - test-database
   test-database:
@@ -38,6 +40,6 @@ services:
       context: .
       dockerfile: database/Dockerfile
     ports:
-      - 5432:5432
+      - 6543:5432
     env_file:
       - database.env


### PR DESCRIPTION
This PR is to resolve a few issues when running the API in a local development environment.

- It allows the database migration file to be run against a local development container instance.
- It ensures that the migration isn't run on a test container instance as that environment uses EnsureCreated() to create a db snapshot.