### PR TITLE
Feature/get taxomonies filter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,3 +128,6 @@ dotnet_diagnostic.CA1303.severity = none
 dotnet_diagnostic.CA1001.severity = none
 #Can reassign collections
 dotnet_diagnostic.CA2227.severity = none
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = suggestion

--- a/LBHFSSPublicAPI.Tests/ConnectionString.cs
+++ b/LBHFSSPublicAPI.Tests/ConnectionString.cs
@@ -7,7 +7,7 @@ namespace LBHFSSPublicAPI.Tests
         public static string TestDatabase()
         {
             return $"Host={Environment.GetEnvironmentVariable("DB_HOST") ?? "127.0.0.1"};" +
-                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "5432"};" +
+                   $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "6543"};" +
                    $"Username={Environment.GetEnvironmentVariable("DB_USERNAME") ?? "postgres"};" +
                    $"Password={Environment.GetEnvironmentVariable("DB_PASSWORD") ?? "mypassword"};" +
                    $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "testdb"}";

--- a/LBHFSSPublicAPI.Tests/DatabaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/DatabaseTests.cs
@@ -1,3 +1,4 @@
+using LBHFSSPublicAPI.Tests.TestHelpers;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -19,6 +20,7 @@ namespace LBHFSSPublicAPI.Tests
             DatabaseContext = new DatabaseContext(builder.Options);
             DatabaseContext.Database.EnsureCreated();
             _transaction = DatabaseContext.Database.BeginTransaction();
+            CustomizeAssertions.ApproximationDateTime();
         }
 
         [TearDown]

--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -27,4 +27,7 @@
     <ProjectReference Include="..\LBHFSSPublicAPI\LBHFSSPublicAPI.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="TestHelpers\" />
+  </ItemGroup>
 </Project>

--- a/LBHFSSPublicAPI.Tests/TestHelpers/CustomizeAssertions.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/CustomizeAssertions.cs
@@ -1,0 +1,18 @@
+using System;
+using FluentAssertions;
+
+namespace LBHFSSPublicAPI.Tests.TestHelpers
+{
+    public static class CustomizeAssertions
+    {
+        public static void ApproximationDateTime()
+        {
+            AssertionOptions.AssertEquivalencyUsing(options =>
+            {
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTime>();
+                options.Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTimeOffset>();
+                return options;
+            });
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/V1/Controllers/TaxonomiesControllerTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Controllers/TaxonomiesControllerTests.cs
@@ -33,7 +33,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         {
             var expected = _fixture.CreateMany<TaxonomyEntity>().ToList();
             var expectedResponse = new TaxonomyResponse { Taxonomies = expected };
-            _mockUseCase.Setup(u => u.ExecuteGet()).Returns(expectedResponse);
+            _mockUseCase.Setup(u => u.ExecuteGet(It.IsAny<string>())).Returns(expectedResponse);
             var response = _classUnderTest.GetTaxonomies() as OkObjectResult;
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
@@ -44,7 +44,20 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public void ControllerGetRequestCallsUseCaseGetMethod()
         {
             _classUnderTest.GetTaxonomies();
-            _mockUseCase.Verify(u => u.ExecuteGet(), Times.Once);
+            _mockUseCase.Verify(u => u.ExecuteGet(It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public void GiveRequestWithFilterParameterWhenGetTaxonomiesControllerMethodIsCalledThenItCallsExecuteGetUsecaseMethodWithThatParameter()
+        {
+            // arrange
+            var vocabularyFP = _fixture.Create<string>();
+
+            // act
+            _classUnderTest.GetTaxonomies(vocabularyFP);
+
+            // assert
+            _mockUseCase.Verify(u => u.ExecuteGet(It.Is<string>(p => p == vocabularyFP)), Times.Once);
         }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/TaxonomiesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/TaxonomiesGatewayTests.cs
@@ -22,19 +22,22 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetTaxonomiesReturnsTaxonomies()
+        public void GetTaxonomiesReturnsTaxonomies() // all
         {
             var entity = _fixture.Create<Taxonomy>();
             DatabaseContext.Taxonomies.Add(entity);
             DatabaseContext.SaveChanges();
-            var response = _classUnderTest.GetTaxonomies().ToList();
+            var response = _classUnderTest.GetTaxonomies(null).ToList();
             response.First().Name.Should().Be(entity.Name);
         }
 
         [Test]
-        public void GetTaxonomiesWhenDbIsEmptyReturnsAnEmptyList()
+        public void GetTaxonomiesWhenDbIsEmptyReturnsAnEmptyList() // test independent of null/not null
         {
-            var response = _classUnderTest.GetTaxonomies().ToList();
+            // arrange
+            var vocabularyFP = _fixture.Create<string>();
+
+            var response = _classUnderTest.GetTaxonomies(vocabularyFP).ToList();
             response.Count.Should().Be(0);
         }
     }

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/TaxonomiesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/TaxonomiesGatewayTests.cs
@@ -40,5 +40,43 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             var response = _classUnderTest.GetTaxonomies(vocabularyFP).ToList();
             response.Count.Should().Be(0);
         }
+
+        [Test]
+        public void GivenAFilterParameterWhenGetTaxonomiesGatewayMethodIsCalledThenItReturnsOnlyFilteredTaxonomies() // GatewayReturnsOnlyFilteredTaxonomies
+        {
+            // arrange
+            var vocabularyFP = _fixture.Create<string>();
+
+            var taxonomies = _fixture.CreateMany<Taxonomy>(5).ToList();
+            taxonomies[1].Vocabulary = vocabularyFP;
+            taxonomies[3].Vocabulary = vocabularyFP;
+            DatabaseContext.Taxonomies.AddRange(taxonomies);
+            DatabaseContext.SaveChanges();
+
+            // act
+            var gatewayResult = _classUnderTest.GetTaxonomies(vocabularyFP).ToList();
+
+            // assert
+            gatewayResult.Count.Should().Be(2);
+            gatewayResult.Should().BeEquivalentTo(taxonomies.Where(x => x.Vocabulary == vocabularyFP));
+        }
+
+        [Test]
+        public void GivenAFilterParameterAndNoMatchingResultsWhenGetTaxonomiesGatewayMethodIsCalledThenItReturnsEmptyCollection()
+        {
+            // arrange
+            var vocabularyFP = _fixture.Create<string>();
+
+            var taxonomies = _fixture.CreateMany<Taxonomy>().ToList();
+            DatabaseContext.Taxonomies.AddRange(taxonomies);
+            DatabaseContext.SaveChanges();
+
+            // act
+            var gatewayResult = _classUnderTest.GetTaxonomies(vocabularyFP).ToList();
+
+            // assert
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Count.Should().Be(0);
+        }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/UseCase/TaxonomiesUseCaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/UseCase/TaxonomiesUseCaseTests.cs
@@ -34,12 +34,12 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         }
 
         [Test]
-        public void ReturnsHelpRequests()
+        public void ReturnsHelpRequests() //Wrap up
         {
             var responseData = _fixture.CreateMany<TaxonomyEntity>().ToList();
             _mockTaxonomiesGateway.Setup(g => g.GetTaxonomies()).Returns(responseData);
             var expectedResponse = new TaxonomyResponse { Taxonomies = responseData };
-            var response = _classUnderTest.ExecuteGet();
+            var response = _classUnderTest.ExecuteGet(null);
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(expectedResponse);
         }

--- a/LBHFSSPublicAPI.Tests/V1/UseCase/TaxonomiesUseCaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/UseCase/TaxonomiesUseCaseTests.cs
@@ -29,20 +29,25 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         [Test]
         public void GetTaxonomiesUseCaseCallsGatewayGetTaxonomies()
         {
-            _classUnderTest.ExecuteGet();
-            _mockTaxonomiesGateway.Verify(u => u.GetTaxonomies(), Times.Once);
+            // arrange
+            var vocabularyFP = _fixture.Create<string>();
+
+            // act
+            _classUnderTest.ExecuteGet(vocabularyFP);
+
+            // assert
+            _mockTaxonomiesGateway.Verify(u => u.GetTaxonomies(It.Is<string>(p => p == vocabularyFP)), Times.Once);
         }
 
         [Test]
         public void ReturnsHelpRequests() //Wrap up
         {
             var responseData = _fixture.CreateMany<TaxonomyEntity>().ToList();
-            _mockTaxonomiesGateway.Setup(g => g.GetTaxonomies()).Returns(responseData);
+            _mockTaxonomiesGateway.Setup(g => g.GetTaxonomies(It.IsAny<string>())).Returns(responseData);
             var expectedResponse = new TaxonomyResponse { Taxonomies = responseData };
             var response = _classUnderTest.ExecuteGet(null);
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(expectedResponse);
         }
-
     }
 }

--- a/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
@@ -18,10 +18,10 @@ namespace LBHFSSPublicAPI.V1.Controllers
         }
 
         [HttpGet]
-        [ProducesResponseType(typeof(Dictionary<string, bool>), 200)]
-        public IActionResult GetTaxonomies()
+        //[ProducesResponseType(typeof(Dictionary<string, bool>), 200)]
+        public IActionResult GetTaxonomies([FromQuery] string vocabulary = null)
         {
-            var result = _taxonomiesUseCase.ExecuteGet();
+            var result = _taxonomiesUseCase.ExecuteGet(vocabulary);
             return Ok(result);
         }
     }

--- a/LBHFSSPublicAPI/V1/Gateways/Interfaces/ITaxonomiesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/Interfaces/ITaxonomiesGateway.cs
@@ -6,6 +6,6 @@ namespace LBHFSSPublicAPI.V1.Gateways.Interfaces
 {
     public interface ITaxonomiesGateway
     {
-        List<TaxonomyEntity> GetTaxonomies();
+        List<TaxonomyEntity> GetTaxonomies(string vocabulary);
     }
 }

--- a/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
@@ -14,7 +14,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
         {
             _dbContext = dbContext;
         }
-        public List<TaxonomyEntity> GetTaxonomies()
+        public List<TaxonomyEntity> GetTaxonomies(string vocabulary)
         {
             var gwResponse = _dbContext.Taxonomies.Select(x => new TaxonomyEntity
             {

--- a/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
@@ -16,15 +16,18 @@ namespace LBHFSSPublicAPI.V1.Gateways
         }
         public List<TaxonomyEntity> GetTaxonomies(string vocabulary)
         {
-            var gwResponse = _dbContext.Taxonomies.Where(t => string.IsNullOrWhiteSpace(vocabulary) || t.Vocabulary.ToUpper() == vocabulary.ToUpper()).Select(x => new TaxonomyEntity
-            {
-                Id = x.Id,
-                CreatedAt = x.CreatedAt,
-                Name = x.Name,
-                ParentId = x.ParentId.Value,
-                Vocabulary = x.Vocabulary,
-                Weight = x.Weight
-            });
+            var gwResponse = _dbContext.Taxonomies.Where(
+                t => string.IsNullOrWhiteSpace(vocabulary) ||
+                t.Vocabulary.ToUpper().Contains(vocabulary.ToUpper()))
+                .Select(x => new TaxonomyEntity
+                {
+                    Id = x.Id,
+                    CreatedAt = x.CreatedAt,
+                    Name = x.Name,
+                    ParentId = x.ParentId.Value,
+                    Vocabulary = x.Vocabulary,
+                    Weight = x.Weight
+                });
             return gwResponse.ToList();
         }
     }

--- a/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/TaxonomiesGateway.cs
@@ -16,7 +16,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
         }
         public List<TaxonomyEntity> GetTaxonomies(string vocabulary)
         {
-            var gwResponse = _dbContext.Taxonomies.Select(x => new TaxonomyEntity
+            var gwResponse = _dbContext.Taxonomies.Where(t => string.IsNullOrWhiteSpace(vocabulary) || t.Vocabulary.ToUpper() == vocabulary.ToUpper()).Select(x => new TaxonomyEntity
             {
                 Id = x.Id,
                 CreatedAt = x.CreatedAt,

--- a/LBHFSSPublicAPI/V1/UseCase/Interfaces/ITaxonomiesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/Interfaces/ITaxonomiesUseCase.cs
@@ -5,6 +5,6 @@ namespace LBHFSSPublicAPI.V1.UseCase.Interfaces
 {
     public interface ITaxonomiesUseCase
     {
-        TaxonomyResponse ExecuteGet();
+        TaxonomyResponse ExecuteGet(string vocabulary);
     }
 }

--- a/LBHFSSPublicAPI/V1/UseCase/TaxonomiesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/TaxonomiesUseCase.cs
@@ -15,7 +15,7 @@ namespace LBHFSSPublicAPI.V1.UseCase
         }
         public TaxonomyResponse ExecuteGet(string vocabulary)
         {
-            var response = _gateway.GetTaxonomies();
+            var response = _gateway.GetTaxonomies(vocabulary);
             return new TaxonomyResponse { Taxonomies = response };
         }
     }

--- a/LBHFSSPublicAPI/V1/UseCase/TaxonomiesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/TaxonomiesUseCase.cs
@@ -13,7 +13,7 @@ namespace LBHFSSPublicAPI.V1.UseCase
         {
             _gateway = gateway;
         }
-        public TaxonomyResponse ExecuteGet()
+        public TaxonomyResponse ExecuteGet(string vocabulary)
         {
             var response = _gateway.GetTaxonomies();
             return new TaxonomyResponse { Taxonomies = response };


### PR DESCRIPTION
# What:
- Added Vocabulary filter parameter for the GET Taxonomies endpoint.
- Added filter parameter is optional and doesn't need to be provided.
- Filtering implementation considers the case, where multiple vocabulary values could be concatenated under a single taxonomy vocabulary field. So it performs a substring search. 
- Port number fix so that tests from the code editor could connect to the database.

# Why:
- So that taxonomies to be retrieved could be filtered by synonym or related word search, rather than retrieving them all all the time.

# Notes:
- Fluent assertion date equivalence had to be customised through options as it was failing due that same date being represented in different precision: 

> Expected item[0].CreatedAt to be 
<2020-09-04 07:15:09.3805749>, but found 
<2020-09-04 07:15:09.380574>.

- Suppressed the CA1304 Specify CultureInfo warning into a suggestion because the application is configured to fail to build upon warning. The error was appearing for the methods 'Contains' (in the tests project), 'ToLower', 'ToUpper'.
According to net core 3.1 [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.string.contains?view=netcore-3.1), `The 'Contains' method performs an ordinal (case-sensitive and culture-insensitive) comparison.`, so the warning message is out of date here.

As a side effect, that error gets suppressed for 'ToLower' and 'ToUpper' methods as well, however I don't foresee Hackney Council using special characters for vocabulary field that would cause an issue when changing character case.

