### PR TITLE
Feature/search filter by taxonomy

### DIFF
--- a/LBHFSSPublicAPI.Tests/V1/Boundary/Requests/SearchServicesRequestTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Boundary/Requests/SearchServicesRequestTests.cs
@@ -21,7 +21,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary
             Assert.That(entity, Has.Property("Sort").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("Offset").InstanceOf(typeof(int)));
             Assert.That(entity, Has.Property("Limit").InstanceOf(typeof(int)));
-            Assert.That(entity, Has.Property("TaxonomyId").InstanceOf(typeof(int)));
+            Assert.That(entity, Has.Property("TaxonomyIds").InstanceOf(typeof(List<int>)));
             Assert.That(entity, Has.Property("PostCode").InstanceOf(typeof(string)));
         }
     }

--- a/LBHFSSPublicAPI.Tests/V1/Controllers/ServicesControllerTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Controllers/ServicesControllerTests.cs
@@ -46,6 +46,15 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
                 uc.ExecuteGet(It.Is<SearchServicesRequest>(p => p == searchParams)), Times.Once);
         }
 
+        [TestCase(TestName = "When the services controller GetService action is called with a taxonomy id the ServicesUseCase ExecuteGet method is called once with the parameter specified")]
+        public void ServiceControllerSearchServiceActionWithTaxonomyIdCallsTheServicesUseCaseWithTheCorrectTaxonomyId()
+        {
+            var searchParams = Randomm.Create<SearchServicesRequest>();
+            _classUnderTest.SearchServices(searchParams);
+            _mockUseCase.Verify(uc =>
+                uc.ExecuteGet(It.Is<SearchServicesRequest>(p => p.TaxonomyIds == searchParams.TaxonomyIds)), Times.Once);
+        }
+
 
         [Test]
         public void ReturnsResponseWithStatus()

--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/SearchServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/SearchServices.cs
@@ -67,5 +67,42 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
             var deserializedBody = JsonConvert.DeserializeObject<GetServiceResponseList>(stringContent);
             deserializedBody.Services.Count.Should().Be(2);
         }
+
+        [TestCase(TestName =
+            "Given that there are services in the database, if a taxonomy id search parameter is provided, services with taxonomy with id")]
+        public async Task GetServicesByTaxonomyIdServicesIfMatchedToTaxonomyId()
+        {
+            var taxonomy1 = EntityHelpers.CreateTaxonomy();
+            var taxonomy2 = EntityHelpers.CreateTaxonomy();
+            var services = EntityHelpers.CreateServices();
+            var serviceToFind1 = EntityHelpers.CreateService();
+            var serviceToFind2 = EntityHelpers.CreateService();
+            var serviceTaxonomy1 = EntityHelpers.CreateServiceTaxonomy();
+            var serviceTaxonomy2 = EntityHelpers.CreateServiceTaxonomy();
+            var serviceTaxonomy3 = EntityHelpers.CreateServiceTaxonomy();
+            var searchTerm = Randomm.Create<string>();
+            serviceToFind1.Name += searchTerm;
+            serviceToFind2.Name += searchTerm;
+            serviceTaxonomy1.Service = serviceToFind1;
+            serviceTaxonomy1.Taxonomy = taxonomy1;
+            serviceTaxonomy2.Service = serviceToFind2;
+            serviceTaxonomy2.Taxonomy = taxonomy2;
+            serviceTaxonomy3.Service = services.First();
+            serviceTaxonomy3.Taxonomy = taxonomy2;
+            DatabaseContext.Services.AddRange(services);
+            DatabaseContext.Services.Add(serviceToFind1);
+            DatabaseContext.Services.Add(serviceToFind2);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy1);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy2);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy3);
+            DatabaseContext.SaveChanges();
+            var requestUri = new Uri($"api/v1/services?search={searchTerm}&taxonomyids={taxonomy1.Id}&taxonomyids={taxonomy2.Id}", UriKind.Relative);
+            var response = Client.GetAsync(requestUri).Result;
+            response.StatusCode.Should().Be(200);
+            var content = response.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+            var deserializedBody = JsonConvert.DeserializeObject<GetServiceResponseList>(stringContent);
+            deserializedBody.Services.Count.Should().Be(2);
+        }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -117,6 +117,36 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             gatewayResult.Should().NotBeNull();
             gatewayResult.Count.Should().Be(expectedData.Count);
         }
+
+        [TestCase(TestName = "Given taxonomy id search parameter when the SearchService method is called it returns records matching taxonomy id")]
+        public void GivenTaxonomyIdSearchParametersWhenSearchServicesGatewayMethodIsCalledThenItReturnsMatchingTaxonomyIdResults()
+        {
+            var taxonomy1 = EntityHelpers.CreateTaxonomy();
+            var taxonomy2 = EntityHelpers.CreateTaxonomy();
+            var services = EntityHelpers.CreateServices();
+            var serviceToFind1 = EntityHelpers.CreateService();
+            var serviceToFind2 = EntityHelpers.CreateService();
+            var serviceTaxonomy1 = EntityHelpers.CreateServiceTaxonomy();
+            var serviceTaxonomy2 = EntityHelpers.CreateServiceTaxonomy();
+            serviceTaxonomy1.Service = serviceToFind1;
+            serviceTaxonomy1.Taxonomy = taxonomy1;
+            serviceTaxonomy2.Service = serviceToFind2;
+            serviceTaxonomy2.Taxonomy = taxonomy2;
+            DatabaseContext.Services.AddRange(services);
+            DatabaseContext.Services.Add(serviceToFind1);
+            DatabaseContext.Services.Add(serviceToFind2);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy1);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy2);
+            DatabaseContext.SaveChanges();
+            var requestParams = new SearchServicesRequest();
+            requestParams.TaxonomyIds = new List<int> { taxonomy1.Id, taxonomy2.Id };
+            var expectedData = new List<Service>();
+            expectedData.Add(serviceToFind1);
+            expectedData.Add(serviceToFind2);
+            var gatewayResult = _classUnderTest.SearchServices(requestParams);
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Count.Should().Be(expectedData.Count);
+        }
         #endregion
     }
 }

--- a/LBHFSSPublicAPI/V1/Boundary/Request/SearchServicesRequest.cs
+++ b/LBHFSSPublicAPI/V1/Boundary/Request/SearchServicesRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBHFSSPublicAPI.V1.Boundary.Request
@@ -7,6 +8,7 @@ namespace LBHFSSPublicAPI.V1.Boundary.Request
         public SearchServicesRequest()
         {
             Limit = 0;
+            TaxonomyIds = new List<int>();
         }
 
         [FromQuery]
@@ -19,7 +21,7 @@ namespace LBHFSSPublicAPI.V1.Boundary.Request
         public int Offset { get; set; }
 
         [FromQuery]
-        public int TaxonomyId { get; set; }
+        public List<int> TaxonomyIds { get; set; }
 
         [FromQuery]
         public int Limit { get; set; }

--- a/LBHFSSPublicAPI/V1/Infrastructure/ServiceTaxonomy.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/ServiceTaxonomy.cs
@@ -5,8 +5,8 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
     public partial class ServiceTaxonomy
     {
         public int Id { get; set; }
-        public int? ServiceId { get; set; }
-        public int? TaxonomyId { get; set; }
+        public int ServiceId { get; set; }
+        public int TaxonomyId { get; set; }
         public string Description { get; set; }
 
         public virtual Service Service { get; set; }


### PR DESCRIPTION
Search results can now filter by taxonomy.
- When a search term is provided with the optional taxonomies parameter, the search results are restricted to those services that match any of the provided taxonomy ids.