### PR TITLE
Feature get single service postcode distance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: docker-compose build fss-public-api-test
       - run:
           name: Run tests
-          command: docker-compose run fss-public-api-test
+          command: docker-compose run fss-public-api-test -e ADDRESSES_API_BASE_URL ADDRESSES_API_KEY
   assume-role-development:
     executor: docker-python
     steps:
@@ -214,7 +214,8 @@ workflows:
   check-and-deploy-development:
     jobs:
       - check-code-formatting
-      - build-and-test
+      - build-and-test:
+          context: find-support-services-public-api-context
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
@@ -244,6 +245,7 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:
+          context: find-support-services-public-api-context
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: docker-compose build fss-public-api-test
       - run:
           name: Run tests
-          command: docker-compose run fss-public-api-test -e ADDRESSES_API_BASE_URL ADDRESSES_API_KEY
+          command: docker-compose run -e ADDRESSES_API_BASE_URL -e ADDRESSES_API_KEY --rm fss-public-api-test
   assume-role-development:
     executor: docker-python
     steps:

--- a/.editorconfig
+++ b/.editorconfig
@@ -131,3 +131,6 @@ dotnet_diagnostic.CA2227.severity = none
 
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = suggestion
+
+# CA1307: Specify StringComparison
+dotnet_diagnostic.CA1307.severity = suggestion

--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Geolocation" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -64,6 +64,8 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             var serviceLocation = Randomm.Build<ServiceLocation>()
                 .Without(sl => sl.Id)
+                .With(sl => sl.Latitude, (decimal) Randomm.Latitude())
+                .With(sl => sl.Longitude, (decimal) Randomm.Longitude())
                 .With(sl => sl.Service, Randomm.Build<Service>()
                     .Without(s => s.Id)
                     .With(s => s.Organization, CreateOrganization())

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -26,6 +26,10 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             return _faker.Random.Int(minimum, maximum);
         }
+        public static string Word()
+        {
+            return _faker.Random.Word();
+        }
         public static string Text()
         {
             return string.Join(" ", _faker.Random.Words(5));
@@ -102,22 +106,29 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             return listOfAddresses;
         }
 
-        private static ErrorEntity FakeError()
+        private static ErrorEntity FakeError(bool isServerErrorResponse)
         {
             return _fixture.Build<ErrorEntity>()
                 .With(e => e.IsValid, false)
-                .With(e => e.Errors, null)
-                .With(e => e.ValidationErrors, _fixture.CreateMany<ValidationErrorEntity>().ToList())
+                .With(e => e.Errors,
+                    isServerErrorResponse ?
+                    new List<ExecutionErrorEntity> { _fixture.Create<ExecutionErrorEntity>() } :
+                    null)
+                .With(e => e.ValidationErrors,
+                    isServerErrorResponse ?
+                    null :
+                    _fixture.CreateMany<ValidationErrorEntity>().ToList())
                 .Create();
         }
 
         private static string FakeAddressesAPIJsonResponse(int statusCode, Coordinate coordinate, bool populateAddressCollection)
         {
             var isStatus200 = statusCode == 200;
+            var isStatus500 = statusCode == 500;
 
             var fakeResponse = _fixture.Build<RootAPIResponseEntity>()
                 .With(r => r.Data, isStatus200 ? FakeData(coordinate, populateAddressCollection) : null)
-                .With(r => r.Error, isStatus200 ? null : FakeError())
+                .With(r => r.Error, isStatus200 ? null : FakeError(isStatus500))
                 .With(r => r.StatusCode, statusCode)
                 .Create();
 

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -9,6 +9,7 @@ using Bogus;
 using Geolocation;
 using LBHFSSPublicAPI.V1.Domain;
 using LBHFSSPublicAPI.V1.Infrastructure;
+using LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities;
 using Newtonsoft.Json;
 
 namespace LBHFSSPublicAPI.Tests.TestHelpers
@@ -77,19 +78,19 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
 
         #region Addresses API Fake Response
 
-        private static List<FakeAddress> FakeAddresses()
+        private static List<AddressEntity> FakeAddresses()
         {
-            return _fixture.Build<FakeAddress>()
+            return _fixture.Build<AddressEntity>()
                 .With(a => a.Longitude, Longitude())
                 .With(a => a.Latitude, Latitude())
                 .CreateMany()
                 .ToList();
         }
 
-        private static FakeData FakeData(Coordinate coordinate, bool populateAddressCollection)
+        private static DataEntity FakeData(Coordinate coordinate, bool populateAddressCollection)
         {
-            var listOfAddresses = _fixture.Build<FakeData>()
-                .With(d => d.Address, populateAddressCollection ? FakeAddresses() : new List<FakeAddress>())
+            var listOfAddresses = _fixture.Build<DataEntity>()
+                .With(d => d.Address, populateAddressCollection ? FakeAddresses() : new List<AddressEntity>())
                 .Create();
 
             if (populateAddressCollection)
@@ -101,12 +102,12 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             return listOfAddresses;
         }
 
-        private static FakeError FakeError()
+        private static ErrorEntity FakeError()
         {
-            return _fixture.Build<FakeError>()
+            return _fixture.Build<ErrorEntity>()
                 .With(e => e.IsValid, false)
                 .With(e => e.Errors, null)
-                .With(e => e.ValidationErrors, _fixture.CreateMany<FakeValidationError>().ToList())
+                .With(e => e.ValidationErrors, _fixture.CreateMany<ValidationErrorEntity>().ToList())
                 .Create();
         }
 
@@ -114,7 +115,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             var isStatus200 = statusCode == 200;
 
-            var fakeResponse = _fixture.Build<FakeAddressesAPIJsonResponse>()
+            var fakeResponse = _fixture.Build<RootAPIResponseEntity>()
                 .With(r => r.Data, isStatus200 ? FakeData(coordinate, populateAddressCollection) : null)
                 .With(r => r.Error, isStatus200 ? null : FakeError())
                 .With(r => r.StatusCode, statusCode)
@@ -161,85 +162,5 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             fixture.Customizations.Add(new IgnoreVirtualMembers());
         }
     }
-    #endregion
-
-    #region Addresses API response classes - required for testing.
-
-    // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
-
-    /// <summary>
-    /// Classes generated based of Addresses API response. Only used for testing purposes
-    /// to generate random, but structured string responses.
-    /// </summary>
-    public class FakeAddress
-    {
-        public string AddressKey { get; set; }
-        public int Uprn { get; set; }
-        public int Usrn { get; set; }
-        public int ParentUPRN { get; set; }
-        public string AddressStatus { get; set; }
-        public string UnitName { get; set; }
-        public object UnitNumber { get; set; }
-        public object BuildingName { get; set; }
-        public string BuildingNumber { get; set; }
-        public string Street { get; set; }
-        public string Postcode { get; set; }
-        public string Locality { get; set; }
-        public string Town { get; set; }
-        public string Gazetteer { get; set; }
-        public string CommercialOccupier { get; set; }
-        public string Ward { get; set; }
-        public string UsageDescription { get; set; }
-        public string UsagePrimary { get; set; }
-        public string UsageCode { get; set; }
-        public string PlanningUseClass { get; set; }
-        public bool PropertyShell { get; set; }
-        public bool HackneyGazetteerOutOfBoroughAddress { get; set; }
-        public double Easting { get; set; }
-        public double Northing { get; set; }
-        public double Longitude { get; set; }
-        public double Latitude { get; set; }
-        public int AddressStartDate { get; set; }
-        public int AddressEndDate { get; set; }
-        public int AddressChangeDate { get; set; }
-        public int PropertyStartDate { get; set; }
-        public int PropertyEndDate { get; set; }
-        public int PropertyChangeDate { get; set; }
-        public string Line1 { get; set; }
-        public string Line2 { get; set; }
-        public string Line3 { get; set; }
-        public string Line4 { get; set; }
-    }
-
-    public class FakeData
-    {
-        public List<FakeAddress> Address { get; set; }
-
-#pragma warning disable CA1707 // Identifiers should not contain underscores
-        public int Page_count { get; set; }
-        public int Total_count { get; set; }
-#pragma warning restore CA1707 // Identifiers should not contain underscores
-    }
-
-    public class FakeAddressesAPIJsonResponse
-    {
-        public FakeData Data { get; set; }
-        public int StatusCode { get; set; }
-        public object Error { get; set; }
-    }
-
-    public class FakeValidationError
-    {
-        public string Message { get; set; }
-        public string FieldName { get; set; }
-    }
-
-    public class FakeError
-    {
-        public bool IsValid { get; set; }
-        public object Errors { get; set; }
-        public List<FakeValidationError> ValidationErrors { get; set; }
-    }
-
     #endregion
 }

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using AutoFixture;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
 using Bogus;
 using LBHFSSPublicAPI.V1.Domain;
+using LBHFSSPublicAPI.V1.Infrastructure;
+using Newtonsoft.Json;
+
 namespace LBHFSSPublicAPI.Tests.TestHelpers
 {
     public static class Randomm
@@ -44,6 +48,70 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         }
 
         #endregion
+
+        #region Addresses API Fake Response
+
+        /// <summary>
+        /// Coordinate bounds (Lon, Lat) of a Rectangle surrounding
+        /// Hackey. Some parts of rectangle are outside hackney.
+        /// </summary>
+        /// <returns></returns>
+        public static double Longitude()
+        {
+            return _faker.Random.Double(-0.11, 0);
+        }
+
+        public static double Latitude()
+        {
+            return _faker.Random.Double(51.513, 51.58);
+        }
+
+        private static List<FakeAddress> FakeAddresses()
+        {
+            return _fixture.Build<FakeAddress>()
+                .With(a => a.Longitude, Longitude())
+                .With(a => a.Latitude, Latitude())
+                .CreateMany()
+                .ToList();
+        }
+
+        private static FakeData FakeData()
+        {
+            return _fixture.Build<FakeData>()
+                .With(d => d.Address, FakeAddresses())
+                .Create();
+        }
+
+        private static FakeError FakeError()
+        {
+            return _fixture.Build<FakeError>()
+                .With(e => e.IsValid, false)
+                .With(e => e.Errors, null)
+                .With(e => e.ValidationErrors, _fixture.CreateMany<FakeValidationError>().ToList())
+                .Create();
+        }
+
+        private static string FakeAddressesAPIJsonResponse(int statusCode)
+        {
+            var isStatus200 = statusCode == 200;
+
+            var fakeResponse = _fixture.Build<FakeAddressesAPIJsonResponse>()
+                .With(r => r.Data, isStatus200 ? FakeData() : null)
+                .With(r => r.Error, isStatus200 ? null : FakeError())
+                .With(r => r.StatusCode, statusCode)
+                .Create();
+
+            return JsonConvert.SerializeObject(fakeResponse);
+        }
+
+        public static AddressesAPIContextResponse AddressesAPIContextResponse(int statusCode)
+        {
+            return new AddressesAPIContextResponse(
+                statusCode,
+                FakeAddressesAPIJsonResponse(statusCode));
+        }
+
+        #endregion
     }
     #region Autofixture Customization
     public class IgnoreVirtualMembers : ISpecimenBuilder
@@ -67,5 +135,85 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             fixture.Customizations.Add(new IgnoreVirtualMembers());
         }
     }
+    #endregion
+
+    #region Addresses API response classes - required for testing.
+
+    // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
+
+    /// <summary>
+    /// Classes generated based of Addresses API response. Only used for testing purposes
+    /// to generate random, but structured string responses.
+    /// </summary>
+    public class FakeAddress
+    {
+        public string AddressKey { get; set; }
+        public int Uprn { get; set; }
+        public int Usrn { get; set; }
+        public int ParentUPRN { get; set; }
+        public string AddressStatus { get; set; }
+        public string UnitName { get; set; }
+        public object UnitNumber { get; set; }
+        public object BuildingName { get; set; }
+        public string BuildingNumber { get; set; }
+        public string Street { get; set; }
+        public string Postcode { get; set; }
+        public string Locality { get; set; }
+        public string Town { get; set; }
+        public string Gazetteer { get; set; }
+        public string CommercialOccupier { get; set; }
+        public string Ward { get; set; }
+        public string UsageDescription { get; set; }
+        public string UsagePrimary { get; set; }
+        public string UsageCode { get; set; }
+        public string PlanningUseClass { get; set; }
+        public bool PropertyShell { get; set; }
+        public bool HackneyGazetteerOutOfBoroughAddress { get; set; }
+        public double Easting { get; set; }
+        public double Northing { get; set; }
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+        public int AddressStartDate { get; set; }
+        public int AddressEndDate { get; set; }
+        public int AddressChangeDate { get; set; }
+        public int PropertyStartDate { get; set; }
+        public int PropertyEndDate { get; set; }
+        public int PropertyChangeDate { get; set; }
+        public string Line1 { get; set; }
+        public string Line2 { get; set; }
+        public string Line3 { get; set; }
+        public string Line4 { get; set; }
+    }
+
+    public class FakeData
+    {
+        public List<FakeAddress> Address { get; set; }
+
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+        public int Page_count { get; set; }
+        public int Total_count { get; set; }
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+    }
+
+    public class FakeAddressesAPIJsonResponse
+    {
+        public FakeData Data { get; set; }
+        public int StatusCode { get; set; }
+        public object Error { get; set; }
+    }
+
+    public class FakeValidationError
+    {
+        public string Message { get; set; }
+        public string FieldName { get; set; }
+    }
+
+    public class FakeError
+    {
+        public bool IsValid { get; set; }
+        public object Errors { get; set; }
+        public List<FakeValidationError> ValidationErrors { get; set; }
+    }
+
     #endregion
 }

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -60,12 +60,12 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         /// Hackey. Some parts of rectangle are outside hackney.
         /// </summary>
         /// <returns></returns>
-        private static double Longitude()
+        public static double Longitude()
         {
             return _faker.Random.Double(-0.11, 0);
         }
 
-        private static double Latitude()
+        public static double Latitude()
         {
             return _faker.Random.Double(51.513, 51.58);
         }

--- a/LBHFSSPublicAPI.Tests/V1/Boundary/Response/GetServiceResponseTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Boundary/Response/GetServiceResponseTests.cs
@@ -14,7 +14,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary
         public void GetServiceResponseObjectShouldHaveCorrectProperties()
         {
             var entityType = typeof(GetServiceResponse);
-            entityType.GetProperties().Length.Should().Be(12);
+            entityType.GetProperties().Length.Should().Be(13);
             var entity = Randomm.Create<GetServiceResponse>();
             Assert.That(entity, Has.Property("Id").InstanceOf(typeof(int)));
             Assert.That(entity, Has.Property("Name").InstanceOf(typeof(string)));
@@ -28,6 +28,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary
             Assert.That(entity, Has.Property("Referral").InstanceOf(typeof(Referral)));
             Assert.That(entity, Has.Property("Social").InstanceOf(typeof(Social)));
             Assert.That(entity, Has.Property("Status").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("Metadata").InstanceOf(typeof(Metadata)));
         }
 
         [Test]
@@ -81,8 +82,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary
             var entityType = typeof(Location);
             entityType.GetProperties().Length.Should().Be(10);
             var entity = Randomm.Create<Location>();
-            Assert.That(entity, Has.Property("Latitude").InstanceOf(typeof(decimal)));
-            Assert.That(entity, Has.Property("Longitude").InstanceOf(typeof(decimal)));
+            Assert.That(entity, Has.Property("Latitude").InstanceOf(typeof(double)));
+            Assert.That(entity, Has.Property("Longitude").InstanceOf(typeof(double)));
             Assert.That(entity, Has.Property("Uprn").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("Address1").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("Address2").InstanceOf(typeof(string)));
@@ -126,5 +127,16 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary
             Assert.That(entity, Has.Property("Linkedin").InstanceOf(typeof(string)));
         }
 
+        [Test]
+        public void GetServiceResponseMetadataObjectShouldHaveCorrectProperties()
+        {
+            var entityType = typeof(Metadata);
+            entityType.GetProperties().Length.Should().Be(4);
+            var entity = Randomm.Create<Metadata>();
+            Assert.That(entity, Has.Property("PostCode").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("PostCodeLatitude").InstanceOf(typeof(double?)));
+            Assert.That(entity, Has.Property("PostCodeLongitude").InstanceOf(typeof(double?)));
+            Assert.That(entity, Has.Property("Error").InstanceOf(typeof(string)));
+        }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
@@ -23,7 +23,7 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
             var expectedService = DatabaseContext.Services.FirstOrDefault();
             var searchSearviceId = expectedService.Id;
             // act
-            var requestUri = new Uri($"api/v1/services/{searchSearviceId}?postcode={Randomm.Text()}", UriKind.Relative);
+            var requestUri = new Uri($"api/v1/services/{searchSearviceId}?postcode={Randomm.Postcode()}", UriKind.Relative);
             var response = Client.GetAsync(requestUri).Result;
             var content = response.Content;
             var stringResponse = await content.ReadAsStringAsync().ConfigureAwait(true);

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Net;
+using FluentAssertions;
+using Geolocation;
+using LBHFSSPublicAPI.Tests.TestHelpers;
+using LBHFSSPublicAPI.V1.Exceptions;
+using LBHFSSPublicAPI.V1.Gateways;
+using LBHFSSPublicAPI.V1.Gateways.Interfaces;
+using LBHFSSPublicAPI.V1.Infrastructure;
+using Moq;
+using NUnit.Framework;
+
+namespace LBHFSSPublicAPI.Tests.V1.Gateways
+{
+    [TestFixture]
+    public class AddressesGatewayTests
+    {
+        private IAddressesGateway _classUnderTest;
+        private Mock<IAddressesAPIContext> _mockAddressesAPIContext;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockAddressesAPIContext = new Mock<IAddressesAPIContext>();
+            _classUnderTest = new AddressesGateway(_mockAddressesAPIContext.Object);
+        }
+
+        [TestCase(TestName = "Given a postcode, When Addresses gateway GetPostcodeCoordinates method is called, Then it calls Addresses API context's GetAddressesRequest method With that postcode.")]
+        public void AddressesGatewayShouldCallAddressesContextWithGivenPostcode()
+        {
+            // arrange
+            var postcode = Randomm.Postcode();
+
+            // act
+            _classUnderTest.GetPostcodeCoordinates(postcode);
+
+            // assert
+            _mockAddressesAPIContext.Verify(c => c.GetAddressesRequest(It.Is<string>(p => p == postcode)), Times.Once);
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When successful response With nonempty addresses collection is returned, Then the AddressesGateway returns coordinates of the first address in that collection.")]
+        public void Success()
+        {
+            // arrange
+            var expectedCoordinates = Randomm.Coordinates();
+            var contextResponse = Randomm.AddressesAPIContextResponse(200, expectedCoordinates);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            var gatewayResponse = _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayResponse.Should().BeEquivalentTo(expectedCoordinates);
+
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When successful response With empty addresses collection is returned, Then the AddressesGateway returns null coordinates object.")]
+        public void AddressGatewayShouldReturnNullCoordinatesWhenNoAddressesForAGivenPostcodeWereFound()
+        {
+            // arrange
+            var contextResponse = Randomm.AddressesAPIContextResponse(200);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            var gatewayResponse = _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayResponse.Should().Be(null);
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When bad request response With a list validation failures is returned, Then the AddressesGateway throws BadAPICallException.")]
+        public void AddressesGatewatShouldThrowAnErrorWhenAPICallIsConsideredInvalid()
+        {
+            // arrange
+            var contextResponse = Randomm.AddressesAPIContextResponse(400);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayCall.Should().Throw<BadAPICallException>().And.Message.Should().NotBeEmpty();
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When forbidden response is returned, Then the AddressesGateway throws APICallNotAuthorizedException With message telling which API call failed.")]
+        public void AddressesGatewayShouldThrowAnErrorWhenAPICallAuthenticationFails() //Forbidden - Gateway should tell that API key is incorrect - TODO: Integration test.
+        {
+            // arrange
+            var statusCode = 403;
+            var forbiddenResp = "{\"message\":\"Forbidden\"}";
+            var contextResponse = new AddressesAPIContextResponse(statusCode, forbiddenResp);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayCall.Should().Throw<APICallNotAuthorizedException>().WithMessage($"A call to {"Addresses"} API was not authorized.");
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When internal server error response is returned, Then the AddressesGateway throws APICallInternalException.")] // TODO: test exception message
+        public void AddressesGatewayShouldThrowAnErrorWhenAPICallReturnInternalFailure()
+        {
+            // arrange
+            var contextResponse = Randomm.AddressesAPIContextResponse(500);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            //assert
+            gatewayCall.Should().Throw<APICallInternalException>();
+        }
+
+        [TestCase(200, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(400, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(500, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(9000, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        public void AddressesGatewayShouldThrowAnErrorWhenAPICallReturnsUnexpectedSchema(int statusCode) // if anything about the Addresses API changes, ResponseSchemaNotRecognisedException //TODO: should contain api name
+        {
+            // arrange
+            var contextResponse = Randomm.AddressesAPIContextResponse(statusCode == 9000 ? 400 : statusCode);
+            
+            switch (statusCode) {
+                case 200:
+                    contextResponse.JsonContent =
+                        contextResponse.JsonContent.Replace("Data", Randomm.Word());
+                    break;
+                case 400:
+                    contextResponse.JsonContent =
+                        contextResponse.JsonContent.Replace("validationErrors", Randomm.Word());
+                    break;
+                case 500:
+                    contextResponse.JsonContent =
+                        contextResponse.JsonContent.Replace("Errors", Randomm.Word());
+                    break;
+                default:
+                    contextResponse.JsonContent =
+                        contextResponse.JsonContent.Replace("error", Randomm.Word());
+                    break;
+            }
+
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayCall.Should().Throw<ResponseSchemaNotRecognisedException>();
+        }
+
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When an unexpected exception is thrown during its execution, Then the AddressesGateway rethrows that exception so it could be handled elsewhere.")] // it should be handled where all the other exceptions are handled. Gateway can't be the one handling it because as requested it only has to return the coordinates. TODO: improve on this.
+        public void GivenAnUnexpectedExceptionIsThrownInTheGatewayThenItShouldRethrowThatException() // Like WebException (Timeout, Connect failure)
+        {
+            // arrange
+            var expectedException = new WebException(Randomm.Word(), WebExceptionStatus.Timeout);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>()))
+                .Throws(expectedException);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayCall.Should().Throw<WebException>();
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
@@ -102,6 +102,22 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             gatewayCall.Should().Throw<APICallNotAuthorizedException>().WithMessage($"A call to {"Addresses"} API was not authorized.");
         }
 
+        [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When not found response is returned, Then the AddressesGateway throws APICallNotFoundException.")] // ideally would tell the url path or similar
+        public void AddressesGatewayShouldThrowAnErrorWhenAPICallResultsInNotFound()
+        {
+            // arrange
+            var statusCode = 404;
+            var forbiddenResp = "";
+            var contextResponse = new AddressesAPIContextResponse(statusCode, forbiddenResp);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(contextResponse);
+
+            // act
+            Action gatewayCall = () => _classUnderTest.GetPostcodeCoordinates(It.IsAny<string>());
+
+            // assert
+            gatewayCall.Should().Throw<APICallNotFoundException>();
+        }
+
         [TestCase(TestName = "Given Addresses API context's GetAddressesRequest method is called, When internal server error response is returned, Then the AddressesGateway throws APICallInternalException.")] // TODO: test exception message
         public void AddressesGatewayShouldThrowAnErrorWhenAPICallReturnInternalFailure()
         {
@@ -124,8 +140,9 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
         {
             // arrange
             var contextResponse = Randomm.AddressesAPIContextResponse(statusCode == 9000 ? 400 : statusCode);
-            
-            switch (statusCode) {
+
+            switch (statusCode)
+            {
                 case 200:
                     contextResponse.JsonContent =
                         contextResponse.JsonContent.Replace("Data", Randomm.Word()

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/AddressesGatewayTests.cs
@@ -28,6 +28,10 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
         [TestCase(TestName = "Given a postcode, When Addresses gateway GetPostcodeCoordinates method is called, Then it calls Addresses API context's GetAddressesRequest method With that postcode.")]
         public void AddressesGatewayShouldCallAddressesContextWithGivenPostcode()
         {
+            // rubbish arrange
+            var irrelevantResponse = Randomm.AddressesAPIContextResponse(200);
+            _mockAddressesAPIContext.Setup(c => c.GetAddressesRequest(It.IsAny<string>())).Returns(irrelevantResponse);
+
             // arrange
             var postcode = Randomm.Postcode();
 
@@ -112,10 +116,10 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             gatewayCall.Should().Throw<APICallInternalException>();
         }
 
-        [TestCase(200, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
-        [TestCase(400, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
-        [TestCase(500, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
-        [TestCase(9000, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(200, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned With 200, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(400, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned With 400, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(500, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned With 500, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
+        [TestCase(9000, TestName = "Given Addresses API context's GetAddressesRequest method is called, When unexpected schema response is returned With 400, Then the AddressesGateway throws ResponseSchemaNotRecognisedException.")]
         public void AddressesGatewayShouldThrowAnErrorWhenAPICallReturnsUnexpectedSchema(int statusCode) // if anything about the Addresses API changes, ResponseSchemaNotRecognisedException //TODO: should contain api name
         {
             // arrange
@@ -124,19 +128,23 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             switch (statusCode) {
                 case 200:
                     contextResponse.JsonContent =
-                        contextResponse.JsonContent.Replace("Data", Randomm.Word());
+                        contextResponse.JsonContent.Replace("Data", Randomm.Word()
+                        , StringComparison.OrdinalIgnoreCase);
                     break;
                 case 400:
                     contextResponse.JsonContent =
-                        contextResponse.JsonContent.Replace("validationErrors", Randomm.Word());
+                        contextResponse.JsonContent.Replace("validationErrors", Randomm.Word()
+                        , StringComparison.OrdinalIgnoreCase);
                     break;
                 case 500:
                     contextResponse.JsonContent =
-                        contextResponse.JsonContent.Replace("Errors", Randomm.Word());
+                        contextResponse.JsonContent.Replace("Errors", Randomm.Word()
+                        , StringComparison.OrdinalIgnoreCase);
                     break;
                 default:
                     contextResponse.JsonContent =
-                        contextResponse.JsonContent.Replace("error", Randomm.Word());
+                        contextResponse.JsonContent.Replace("error", Randomm.Word()
+                        , StringComparison.OrdinalIgnoreCase);
                     break;
             }
 
@@ -163,5 +171,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             // assert
             gatewayCall.Should().Throw<WebException>();
         }
+
+        // TODO: Add NotFound - API could potentially be moved.
+        // TODO: Add Other status code.
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/UseCase/ServicesUseCaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/UseCase/ServicesUseCaseTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq;
 using FluentAssertions;
+using Geolocation;
 using LBHFSSPublicAPI.Tests.TestHelpers;
 using LBHFSSPublicAPI.V1.Boundary.Request;
 using LBHFSSPublicAPI.V1.Boundary.Response;
@@ -34,8 +36,13 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         [TestCase(TestName = "Given a valid request parameter when the use case is called the gateway will be called with the unwrapped id")]
         public void GetServicesUseCaseCallsGatewayGetServices()
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var requestParams = Randomm.Create<GetServiceByIdRequest>();
+            requestParams.PostCode = null;
 
             // act
             _classUnderTest.ExecuteGet(requestParams);
@@ -63,8 +70,13 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         [TestCase(TestName = "Given a valid request parameter when the use case is called the gateway will be called with the unwrapped id")]
         public void GivenAnIdWhenGetServiceyUseCaseIsCalledThenItCallsGetServiceyGatewayMethodAndPassesInThatId()
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var reqParams = Randomm.Create<GetServiceByIdRequest>();
+            reqParams.PostCode = null;
 
             // act
             _classUnderTest.ExecuteGet(reqParams);
@@ -76,10 +88,15 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         [TestCase(TestName = "Given a valid request parameter when the use case is called the use case should respond with a valid response object")]
         public void GivenSuccessfulGetServiceyGatewayCallWhenGatewayReturnsAValueThenTheUseCaseReturnsThatSameValue()
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var reqParams = Randomm.Create<GetServiceByIdRequest>();
-            var gatewayResult = EntityHelpers.CreateService().ToDomain();
+            reqParams.PostCode = null;
 
+            var gatewayResult = EntityHelpers.CreateService().ToDomain();
             _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(gatewayResult);
 
             // act
@@ -89,9 +106,13 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
             usecaseResult.Should().BeEquivalentTo(gatewayResult.ToResponse());
         }
 
-        [TestCase(TestName = "Given a valid nonempty postcode, When ExecuteGet Service usecase's method is called, Then it calls the Addresses gateway GetPostcodeCoordinates method.")]
+        [TestCase(TestName = "Given a nonempty postcode, When ExecuteGet Service usecase's method is called, Then it calls the Addresses gateway GetPostcodeCoordinates method.")]
         public void GivenValidPostcodeUsecaseShouldCallAddressesGateway()
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var request = Randomm.Create<GetServiceByIdRequest>();
 
@@ -102,9 +123,13 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
             _mockAddressesGateway.Verify(g => g.GetPostcodeCoordinates(It.IsAny<string>()), Times.Once);
         }
 
-        [TestCase(TestName = "Given a valid nonempty postcode, When ExecuteGet Service usecase's method is called, Then it calls the Addresses gateway GetPostcodeCoordinates method, And pass in that Postcode.")]
+        [TestCase(TestName = "Given a nonempty postcode, When ExecuteGet Service usecase's method is called, Then it calls the Addresses gateway GetPostcodeCoordinates method, And pass in that Postcode.")]
         public void GivenValidPostcodeUsecaseShouldCallAddressesGatewayWithThatPostcode()
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var request = Randomm.Create<GetServiceByIdRequest>();
 
@@ -119,6 +144,10 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         [TestCase(null, TestName = "Given a null postcode, When ExecuteGet Service usecase's method is called, Then it does not call the Addresses gateway GetPostcodeCoordinates method")]
         public void GivenNoPostcodeUsecaseShouldNotCallAddressesGateway(string postcode)
         {
+            // dummy setup
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
             // arrange
             var request = Randomm.Create<GetServiceByIdRequest>();
             request.PostCode = postcode;
@@ -130,7 +159,78 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
             _mockAddressesGateway.Verify(g => g.GetPostcodeCoordinates(It.IsAny<string>()), Times.Never);
         }
 
-        // TODO: Distance calculating helper does its job.
+        // Gateway coordinates:
+
+        [TestCase(TestName = "Given ExecuteGet Service usecase's method calls Addresses gateway GetPostcodeCoordinates method, When gateway returns related postcode's coordinates, Then usecase response includes non null distances to service locations and non null Metadata coordinate fields.")]
+        public void WhenAddressesGatewayReturnsNullThenUsecasePopulatesDistanceAndMetadataFields()
+        {
+            // arrange
+            var request = Randomm.Create<GetServiceByIdRequest>();
+            request.PostCode = Randomm.Postcode();
+
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
+            var expectedPostcodeCoords = Randomm.Coordinates();
+            _mockAddressesGateway.Setup(g => g.GetPostcodeCoordinates(It.IsAny<string>())).Returns(expectedPostcodeCoords);
+
+            // act
+            var usecaseResponse = _classUnderTest.ExecuteGet(request);
+
+            // assert
+            usecaseResponse.Metadata.PostCode.Should().Be(request.PostCode);
+            usecaseResponse.Metadata.PostCodeLatitude.Should().Be(expectedPostcodeCoords.Latitude);
+            usecaseResponse.Metadata.PostCodeLongitude.Should().Be(expectedPostcodeCoords.Longitude);
+            usecaseResponse.Metadata.Error.Should().BeNull();
+            usecaseResponse.Locations.Should().OnlyContain(l => l.Latitude.HasValue && l.Longitude.HasValue ? l.Distance != null : l.Distance == null);
+        }
+
+        [TestCase(TestName = "Given ExecuteGet Service usecase's method calls Addresses gateway GetPostcodeCoordinates method, When gateway returns NULL postcode's coordinates, Then usecase response includes null distances to service locations AND null Metadata coordinate fields.")]
+        public void WhenAddressesGatewayReturnsNullThenUsecasePopulatesDistanceAndMetadataFieldsWithNull()
+        {
+            // arrange
+            var request = Randomm.Create<GetServiceByIdRequest>();
+            request.PostCode = Randomm.Postcode();
+
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
+            _mockAddressesGateway.Setup(g => g.GetPostcodeCoordinates(It.IsAny<string>())).Returns(null as Coordinate?);
+
+            // act
+            var usecaseResponse = _classUnderTest.ExecuteGet(request);
+
+            // assert
+            usecaseResponse.Locations.Should().OnlyContain(l => l.Distance == null);
+            usecaseResponse.Metadata.PostCode.Should().Be(request.PostCode);
+            usecaseResponse.Metadata.PostCodeLatitude.Should().Be(null);
+            usecaseResponse.Metadata.PostCodeLongitude.Should().Be(null);
+            usecaseResponse.Metadata.Error.Should().NotBeNull();
+        }
+
+        [TestCase(TestName = "Given ExecuteGet Service usecase's method calls Addresses gateway GetPostcodeCoordinates method, When gateway throws an exception, Then usecase response includes null distances to service locations AND null Metadata coordinate fields AND non null Error field.")]
+        public void WhenAddressesGatewayThrowsAnExceptionThenUsecasePopulatesTheMetadataErrorField()
+        {
+            // arrange
+            var request = Randomm.Create<GetServiceByIdRequest>();
+            request.PostCode = Randomm.Postcode();
+
+            var expectedService = EntityHelpers.CreateService().ToDomain();
+            _mockServicesGateway.Setup(g => g.GetService(It.IsAny<int>())).Returns(expectedService);
+
+            var expectedException = new Exception(Randomm.Text());
+            _mockAddressesGateway.Setup(g => g.GetPostcodeCoordinates(It.IsAny<string>())).Throws(expectedException);
+
+            // act
+            var usecaseResponse = _classUnderTest.ExecuteGet(request);
+
+            // assert
+            usecaseResponse.Locations.Should().OnlyContain(l => l.Distance == null);
+            usecaseResponse.Metadata.PostCode.Should().Be(request.PostCode);
+            usecaseResponse.Metadata.PostCodeLatitude.Should().Be(null);
+            usecaseResponse.Metadata.PostCodeLongitude.Should().Be(null);
+            usecaseResponse.Metadata.Error.Should().Be(expectedException.Message);
+        }
 
         #endregion
     }

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Geolocation" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Folder Include="terraform\" />
+    <Folder Include="V1\Exceptions\" />
     <Folder Include="V1\Infrastructure\AddressesContextEntities\" />
   </ItemGroup>
 

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -31,6 +31,7 @@
     <Folder Include="terraform\" />
     <Folder Include="V1\Exceptions\" />
     <Folder Include="V1\Infrastructure\AddressesContextEntities\" />
+    <Folder Include="V1\Domain\AddressesAPIDomain\" />
   </ItemGroup>
 
 </Project>

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Folder Include="terraform\" />
+    <Folder Include="V1\Infrastructure\AddressesContextEntities\" />
   </ItemGroup>
 
 </Project>

--- a/LBHFSSPublicAPI/Startup.cs
+++ b/LBHFSSPublicAPI/Startup.cs
@@ -110,6 +110,7 @@ namespace LBHFSSPublicAPI
                     c.IncludeXmlComments(xmlPath);
             });
             ConfigureDbContext(services);
+            ConfigureAddressesAPIContext(services);
             RegisterGateways(services);
             RegisterUseCases(services);
         }
@@ -121,10 +122,27 @@ namespace LBHFSSPublicAPI
                 opt => opt.UseNpgsql(connectionString));
         }
 
+        private static void ConfigureAddressesAPIContext(IServiceCollection services)
+        {
+            var apiBaseUrl = Environment.GetEnvironmentVariable("ADDRESSES_API_BASE_URL")
+                ?? throw new ArgumentNullException("Addresses API base url");
+
+            var apiKey = Environment.GetEnvironmentVariable("ADDRESSES_API_KEY")
+                ?? throw new ArgumentNullException("Addresses API key");
+
+            var connOptions = new AddressesAPIConnectionOptions(apiBaseUrl, apiKey);
+
+            services.AddScoped<IAddressesAPIContext>(s =>
+            {
+                return new AddressesAPIContext(connOptions);
+            });
+        }
+
         private static void RegisterGateways(IServiceCollection services)
         {
             services.AddScoped<ITaxonomiesGateway, TaxonomiesGateway>();
             services.AddScoped<IServicesGateway, ServicesGateway>();
+            services.AddScoped<IAddressesGateway, AddressesGateway>();
         }
 
         private static void RegisterUseCases(IServiceCollection services)

--- a/LBHFSSPublicAPI/V1/Boundary/Request/GetServiceByIdRequest.cs
+++ b/LBHFSSPublicAPI/V1/Boundary/Request/GetServiceByIdRequest.cs
@@ -8,6 +8,6 @@ namespace LBHFSSPublicAPI.V1.Boundary.Request
         public int Id { get; set; }
 
         [FromQuery(Name = "postCode")]
-        public string PostCode { get; set; }
+        public string PostCode { get; set; } = null;
     }
 }

--- a/LBHFSSPublicAPI/V1/Boundary/Response/GetServiceResponse.cs
+++ b/LBHFSSPublicAPI/V1/Boundary/Response/GetServiceResponse.cs
@@ -17,6 +17,7 @@ namespace LBHFSSPublicAPI.V1.Boundary.Response
         public Referral Referral { get; set; }
         public Social Social { get; set; }
         public string Status { get; set; }
+        public Metadata Metadata { get; set; }
     }
 
     public class Contact
@@ -50,8 +51,8 @@ namespace LBHFSSPublicAPI.V1.Boundary.Response
 
     public class Location
     {
-        public decimal? Latitude { get; set; }
-        public decimal? Longitude { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
         public string Uprn { get; set; }
         public string Address1 { get; set; }
         public string Address2 { get; set; }
@@ -81,5 +82,13 @@ namespace LBHFSSPublicAPI.V1.Boundary.Response
         public string Twitter { get; set; }
         public string Instagram { get; set; }
         public string Linkedin { get; set; }
+    }
+
+    public class Metadata
+    {
+        public string PostCode { get; set; }
+        public double? PostCodeLatitude { get; set; }
+        public double? PostCodeLongitude { get; set; }
+        public string Error { get; set; }
     }
 }

--- a/LBHFSSPublicAPI/V1/Domain/AddressesAPIDomain/AddressDomain.cs
+++ b/LBHFSSPublicAPI/V1/Domain/AddressesAPIDomain/AddressDomain.cs
@@ -1,0 +1,15 @@
+using System;
+namespace LBHFSSPublicAPI.V1.Domain.AddressesAPIDomain
+{
+    public class AddressDomain
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+
+        public AddressDomain(double latitude, double longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Exceptions/APICallInternalException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/APICallInternalException.cs
@@ -1,0 +1,11 @@
+using System;
+namespace LBHFSSPublicAPI.V1.Exceptions
+{
+    public class APICallInternalException : Exception
+    {
+        public APICallInternalException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Exceptions/APICallInternalException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/APICallInternalException.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
+
 namespace LBHFSSPublicAPI.V1.Exceptions
 {
     public class APICallInternalException : Exception
     {
-        public APICallInternalException(string message)
-            : base(message)
+        public APICallInternalException(List<string> errors)
+            : base(String.Join(";\n", errors))
         {
         }
     }

--- a/LBHFSSPublicAPI/V1/Exceptions/APICallNotAuthorizedException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/APICallNotAuthorizedException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace LBHFSSPublicAPI.V1.Exceptions
+{
+    public class APICallNotAuthorizedException : Exception
+    {
+        public APICallNotAuthorizedException(string apiName)
+            : base($"A call to {apiName} API was not authorized.")
+        { }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Exceptions/APICallNotFoundException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/APICallNotFoundException.cs
@@ -1,0 +1,10 @@
+using System;
+namespace LBHFSSPublicAPI.V1.Exceptions
+{
+    public class APICallNotFoundException : Exception
+    {
+        public APICallNotFoundException(string apiName)
+            : base($"A call route to {apiName} API was not found.")
+        { }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Exceptions/BadAPICallException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/BadAPICallException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace LBHFSSPublicAPI.V1.Exceptions
+{
+    public class BadAPICallException : Exception
+    {
+        public BadAPICallException(List<string> validationErrors)
+            : base(String.Join(";\n", validationErrors))
+        {
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Exceptions/ResponseSchemaNotRecognisedException.cs
+++ b/LBHFSSPublicAPI/V1/Exceptions/ResponseSchemaNotRecognisedException.cs
@@ -1,0 +1,11 @@
+using System;
+namespace LBHFSSPublicAPI.V1.Exceptions
+{
+    public class ResponseSchemaNotRecognisedException : Exception
+    {
+        public ResponseSchemaNotRecognisedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
+++ b/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
@@ -57,8 +57,8 @@ namespace LBHFSSPublicAPI.V1.Factories
                     Locations = domain.ServiceLocations
                         .Select(x => new Location
                         {
-                            Latitude = x.Latitude,
-                            Longitude = x.Longitude,
+                            Latitude = (double?) x.Latitude,
+                            Longitude = (double?) x.Longitude,
                             //check if this is a string or integer (does it have preceding 0 or alpa characters)
                             Uprn = x.Uprn.ToString(),
                             Address1 = x.Address1,
@@ -66,7 +66,8 @@ namespace LBHFSSPublicAPI.V1.Factories
                             City = x.City,
                             StateProvince = x.StateProvince,
                             PostalCode = x.PostalCode,
-                            Country = x.Country
+                            Country = x.Country,
+                            Distance = null
                         }).ToList(),
                     Organization =
                         new org.Organization
@@ -83,7 +84,14 @@ namespace LBHFSSPublicAPI.V1.Factories
                         Instagram = domain.Instagram,
                         Linkedin = domain.Linkedin
                     },
-                    Status = domain.Status
+                    Status = domain.Status,
+                    Metadata = new Metadata
+                    {
+                        PostCode = null,
+                        PostCodeLatitude = null,
+                        PostCodeLongitude = null,
+                        Error = null
+                    }
                 };
             return response;
         }

--- a/LBHFSSPublicAPI/V1/Gateways/AddressesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/AddressesGateway.cs
@@ -1,0 +1,65 @@
+using System;
+using LBHFSSPublicAPI.V1.Infrastructure;
+using Geolocation;
+using LBHFSSPublicAPI.V1.Gateways.Interfaces;
+using Newtonsoft.Json;
+using LBHFSSPublicAPI.V1.Exceptions;
+using LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities;
+using System.Linq;
+using LBHFSSPublicAPI.V1.Domain.AddressesAPIDomain;
+
+namespace LBHFSSPublicAPI.V1.Gateways
+{
+    public class AddressesGateway : IAddressesGateway
+    {
+        private readonly IAddressesAPIContext _apiContext;
+
+        public AddressesGateway(IAddressesAPIContext apiContext)
+        {
+            _apiContext = apiContext;
+        }
+
+        public Coordinate? GetPostcodeCoordinates(string postcode)
+        {
+            try
+            {
+                var apiResponse = _apiContext.GetAddressesRequest(postcode);
+                var jsonContent = apiResponse.JsonContent;
+                var statusCode = apiResponse.StatusCode;
+
+                if (statusCode == 400)
+                {
+                    var errResp = JsonConvert.DeserializeObject<RootAPIResponseEntity>(jsonContent);
+                    var errorList = errResp.Error.ValidationErrors.Select(v => v.Message).ToList();
+                    throw new BadAPICallException(errorList);
+                }
+                else if (statusCode == 403)
+                {
+                    throw new APICallNotAuthorizedException("Addresses");
+                }
+                else if (statusCode == 500)
+                {
+                    var errResp = JsonConvert.DeserializeObject<RootAPIResponseEntity>(jsonContent);
+                    var errorList = errResp.Error.Errors.Select(e => e.Message).ToList();
+                    throw new APICallInternalException(errorList);
+                }
+
+                // 200 here, but TODO: should cover other cases to avoid potential errors. Low priority right now, though.
+                var dataResp = JsonConvert.DeserializeObject<RootAPIResponseEntity>(jsonContent);
+                var addressDomain = dataResp.Data.Address.Select(a => new AddressDomain(a.Latitude, a.Longitude)).FirstOrDefault(); // useful if we're going to avarage, which would be sensible, but not for MVP
+
+                return addressDomain != null
+                    ? new Coordinate(addressDomain.Latitude, addressDomain.Longitude)
+                    : null as Coordinate?;
+            }
+            catch (NullReferenceException ex) // No point sending the stacktrace to front-end. TODO: implement logging to log the message.
+            {
+                throw new ResponseSchemaNotRecognisedException($"Addresses API response schema not recognized.");
+            }
+            catch (ArgumentNullException ex) // When Linq is called on empty collection, a different error results
+            {
+                throw new ResponseSchemaNotRecognisedException($"Addresses API response schema not recognized.");
+            }
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Gateways/AddressesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/AddressesGateway.cs
@@ -21,9 +21,10 @@ namespace LBHFSSPublicAPI.V1.Gateways
 
         public Coordinate? GetPostcodeCoordinates(string postcode)
         {
+            var apiResponse = _apiContext.GetAddressesRequest(postcode);
+
             try
             {
-                var apiResponse = _apiContext.GetAddressesRequest(postcode);
                 var jsonContent = apiResponse.JsonContent;
                 var statusCode = apiResponse.StatusCode;
 
@@ -36,6 +37,10 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 else if (statusCode == 403)
                 {
                     throw new APICallNotAuthorizedException("Addresses");
+                }
+                else if (statusCode == 404)
+                {
+                    throw new APICallNotFoundException("Addresses");
                 }
                 else if (statusCode == 500)
                 {

--- a/LBHFSSPublicAPI/V1/Gateways/Interfaces/IAddressesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/Interfaces/IAddressesGateway.cs
@@ -5,6 +5,6 @@ namespace LBHFSSPublicAPI.V1.Gateways.Interfaces
 {
     public interface IAddressesGateway
     {
-        Coordinate GetPostcodeCoordinates(string postcode);
+        Coordinate? GetPostcodeCoordinates(string postcode);
     }
 }

--- a/LBHFSSPublicAPI/V1/Gateways/Interfaces/IAddressesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/Interfaces/IAddressesGateway.cs
@@ -1,0 +1,10 @@
+using System;
+using Geolocation;
+
+namespace LBHFSSPublicAPI.V1.Gateways.Interfaces
+{
+    public interface IAddressesGateway
+    {
+        Coordinate GetPostcodeCoordinates(string postcode);
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIConnectionOptions.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIConnectionOptions.cs
@@ -1,0 +1,14 @@
+namespace LBHFSSPublicAPI.V1.Infrastructure
+{
+    public class AddressesAPIConnectionOptions
+    {
+        public string ApiBaseUrl { get; set; }
+        public string ApiKey { get; set; }
+
+        public AddressesAPIConnectionOptions(string apiBaseUrl, string apiKey)
+        {
+            ApiBaseUrl = apiBaseUrl;
+            ApiKey = apiKey;
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Net.Http;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure
+{
+    public class AddressesAPIContext : IAddressesAPIContext
+    {
+        private readonly string _apiBaseUrl;
+        private readonly string _apiKey;
+        private readonly HttpClient _httpClient = new HttpClient();
+
+        public AddressesAPIContext(AddressesAPIConnectionOptions options)
+        {
+            _apiBaseUrl = options.ApiBaseUrl;
+            _apiKey = options.ApiKey;
+        }
+
+        public AddressesAPIContextResponse GetAddressesRequest(string postcode) // asc Block for now.
+        {
+            // Build the request
+            var request = new HttpRequestMessage();
+            request.Method = HttpMethod.Get;
+            var fullUrlString = $"{_apiBaseUrl}/addresses?PostCode={postcode}&Gazetteer=Both&Format=Detailed"; //Gazeteer Both? or Local?
+            request.RequestUri = new Uri(fullUrlString);
+            request.Headers.Add("x-api-key", _apiKey);
+
+            // Make the request
+            var response = _httpClient.SendAsync(request).Result;
+
+            // Structure Response
+            var statusCode = (int) response.StatusCode;
+            var responseJson = response.Content.ReadAsStringAsync().Result;
+            var contextResponse = new AddressesAPIContextResponse(statusCode, responseJson);
+
+            // Cleanup & Return
+            request.Dispose();
+            response.Dispose();
+            return contextResponse;
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContextResponse.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContextResponse.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure
+{
+    /// <summary>
+    /// Addresses API Context Response. Gateway requires the status code to do decisions on,
+    /// and json string it could deserialize. It should be the Context's responsibility to
+    /// transform a byte stream into a string.
+    /// </summary>
+    public class AddressesAPIContextResponse
+    {
+        public int StatusCode { get; set; }
+        public string JsonContent { get; set; }
+
+        public AddressesAPIContextResponse(int statusCode, string jsonContent)
+        {
+            StatusCode = statusCode;
+            JsonContent = jsonContent;
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/AddressEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/AddressEntity.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class AddressEntity
+    {
+        public string AddressKey { get; set; }
+        public int Uprn { get; set; }
+        public int Usrn { get; set; }
+        public int ParentUPRN { get; set; }
+        public string AddressStatus { get; set; }
+        public string UnitName { get; set; }
+        public object UnitNumber { get; set; }
+        public object BuildingName { get; set; }
+        public string BuildingNumber { get; set; }
+        public string Street { get; set; }
+        public string Postcode { get; set; }
+        public string Locality { get; set; }
+        public string Town { get; set; }
+        public string Gazetteer { get; set; }
+        public string CommercialOccupier { get; set; }
+        public string Ward { get; set; }
+        public string UsageDescription { get; set; }
+        public string UsagePrimary { get; set; }
+        public string UsageCode { get; set; }
+        public string PlanningUseClass { get; set; }
+        public bool PropertyShell { get; set; }
+        public bool HackneyGazetteerOutOfBoroughAddress { get; set; }
+        public double Easting { get; set; }
+        public double Northing { get; set; }
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+        public int AddressStartDate { get; set; }
+        public int AddressEndDate { get; set; }
+        public int AddressChangeDate { get; set; }
+        public int PropertyStartDate { get; set; }
+        public int PropertyEndDate { get; set; }
+        public int PropertyChangeDate { get; set; }
+        public string Line1 { get; set; }
+        public string Line2 { get; set; }
+        public string Line3 { get; set; }
+        public string Line4 { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/AddressEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/AddressEntity.cs
@@ -5,13 +5,13 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
     public class AddressEntity
     {
         public string AddressKey { get; set; }
-        public int Uprn { get; set; }
-        public int Usrn { get; set; }
-        public int ParentUPRN { get; set; }
+        public string Uprn { get; set; }
+        public string Usrn { get; set; }
+        public string ParentUPRN { get; set; }
         public string AddressStatus { get; set; }
         public string UnitName { get; set; }
-        public object UnitNumber { get; set; }
-        public object BuildingName { get; set; }
+        public string UnitNumber { get; set; }
+        public string BuildingName { get; set; }
         public string BuildingNumber { get; set; }
         public string Street { get; set; }
         public string Postcode { get; set; }
@@ -30,12 +30,12 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
         public double Northing { get; set; }
         public double Longitude { get; set; }
         public double Latitude { get; set; }
-        public int AddressStartDate { get; set; }
-        public int AddressEndDate { get; set; }
-        public int AddressChangeDate { get; set; }
-        public int PropertyStartDate { get; set; }
-        public int PropertyEndDate { get; set; }
-        public int PropertyChangeDate { get; set; }
+        public string AddressStartDate { get; set; }
+        public string AddressEndDate { get; set; }
+        public string AddressChangeDate { get; set; }
+        public string PropertyStartDate { get; set; }
+        public string PropertyEndDate { get; set; }
+        public string PropertyChangeDate { get; set; }
         public string Line1 { get; set; }
         public string Line2 { get; set; }
         public string Line3 { get; set; }

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/DataEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/DataEntity.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class DataEntity
+    {
+        public List<AddressEntity> Address { get; set; }
+
+        #pragma warning disable CA1707 // Identifiers should not contain underscores
+        public int Page_count { get; set; }
+        public int Total_count { get; set; }
+        #pragma warning restore CA1707 // Identifiers should not contain underscores
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/DataEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/DataEntity.cs
@@ -7,9 +7,9 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
     {
         public List<AddressEntity> Address { get; set; }
 
-        #pragma warning disable CA1707 // Identifiers should not contain underscores
+#pragma warning disable CA1707 // Identifiers should not contain underscores
         public int Page_count { get; set; }
         public int Total_count { get; set; }
-        #pragma warning restore CA1707 // Identifiers should not contain underscores
+#pragma warning restore CA1707 // Identifiers should not contain underscores
     }
 }

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ErrorEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ErrorEntity.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class ErrorEntity
+    {
+        public bool IsValid { get; set; }
+        public object Errors { get; set; }
+        public List<ValidationErrorEntity> ValidationErrors { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ErrorEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ErrorEntity.cs
@@ -6,7 +6,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
     public class ErrorEntity
     {
         public bool IsValid { get; set; }
-        public object Errors { get; set; }
+        public List<ExecutionErrorEntity> Errors { get; set; }
         public List<ValidationErrorEntity> ValidationErrors { get; set; }
     }
 }

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ExecutionErrorEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ExecutionErrorEntity.cs
@@ -1,0 +1,9 @@
+using System;
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class ExecutionErrorEntity
+    {
+        public string Message { get; set; }
+        public string Code { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/RootAPIResponseEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/RootAPIResponseEntity.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class RootAPIResponseEntity
+    {
+        public DataEntity Data { get; set; }
+        public int StatusCode { get; set; }
+        public ErrorEntity Error { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ValidationErrorEntity.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesContextEntities/ValidationErrorEntity.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities
+{
+    public class ValidationErrorEntity
+    {
+        public string Message { get; set; }
+        public string FieldName { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/IAddressesAPIContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/IAddressesAPIContext.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Net.Http;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure
+{
+    public interface IAddressesAPIContext
+    {
+        AddressesAPIContextResponse GetAddressesRequest(string postcode);
+    }
+}

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -21,7 +21,7 @@ namespace LBHFSSPublicAPI.V1.UseCase
         {
             var gatewayResponse = _servicesGateway.GetService(requestParams.Id);
 
-            if(!string.IsNullOrEmpty(requestParams.PostCode))
+            if (!string.IsNullOrEmpty(requestParams.PostCode))
                 _addressesGateway.GetPostcodeCoordinates(requestParams.PostCode);
 
             return gatewayResponse.ToResponse();

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Geolocation;
 using LBHFSSPublicAPI.V1.Boundary.Request;
 using LBHFSSPublicAPI.V1.Boundary.Response;
 using LBHFSSPublicAPI.V1.Factories;
@@ -17,14 +21,47 @@ namespace LBHFSSPublicAPI.V1.UseCase
             _servicesGateway = servicesGateway;
             _addressesGateway = addressesGateway;
         }
+
         public GetServiceResponse ExecuteGet(GetServiceByIdRequest requestParams)
         {
-            var gatewayResponse = _servicesGateway.GetService(requestParams.Id);
+            var servicesGatewayResponse = _servicesGateway.GetService(requestParams.Id);
+
+            var usecaseResponse = servicesGatewayResponse.ToResponse();
+
+            usecaseResponse.Metadata.PostCode = requestParams.PostCode;
 
             if (!string.IsNullOrEmpty(requestParams.PostCode))
-                _addressesGateway.GetPostcodeCoordinates(requestParams.PostCode);
+                try
+                {
+                    Coordinate? postcodeCoord = _addressesGateway.GetPostcodeCoordinates(requestParams.PostCode);
 
-            return gatewayResponse.ToResponse();
+                    if (postcodeCoord.HasValue)
+                    {
+                        usecaseResponse.Metadata.PostCodeLatitude = postcodeCoord.Value.Latitude;
+                        usecaseResponse.Metadata.PostCodeLongitude = postcodeCoord.Value.Longitude;
+
+                        foreach (var location in usecaseResponse.Locations)
+                            if (location.Latitude.HasValue && location.Longitude.HasValue)
+                                location.Distance =
+                                    GeoCalculator.GetDistance(
+                                        postcodeCoord.Value,
+                                        new Coordinate(location.Latitude.Value, location.Longitude.Value),
+                                        decimalPlaces: 1,
+                                        DistanceUnit.Miles
+                                    ) + " miles";
+
+                    }
+                    else
+                    {
+                        usecaseResponse.Metadata.Error = "Postcode coordinates not found.";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    usecaseResponse.Metadata.Error = ex.Message;
+                }
+
+            return usecaseResponse;
         }
 
         public GetServiceResponseList ExecuteGet(SearchServicesRequest searchParams)

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -9,21 +9,27 @@ namespace LBHFSSPublicAPI.V1.UseCase
 {
     public class ServicesUseCase : IServicesUseCase
     {
-        private readonly IServicesGateway _gateway;
+        private readonly IServicesGateway _servicesGateway;
+        private readonly IAddressesGateway _addressesGateway;
 
-        public ServicesUseCase(IServicesGateway servicesGateway)
+        public ServicesUseCase(IServicesGateway servicesGateway, IAddressesGateway addressesGateway)
         {
-            _gateway = servicesGateway;
+            _servicesGateway = servicesGateway;
+            _addressesGateway = addressesGateway;
         }
         public GetServiceResponse ExecuteGet(GetServiceByIdRequest requestParams)
         {
-            var gatewayResponse = _gateway.GetService(requestParams.Id);
+            var gatewayResponse = _servicesGateway.GetService(requestParams.Id);
+
+            if(!string.IsNullOrEmpty(requestParams.PostCode))
+                _addressesGateway.GetPostcodeCoordinates(requestParams.PostCode);
+
             return gatewayResponse.ToResponse();
         }
 
         public GetServiceResponseList ExecuteGet(SearchServicesRequest searchParams)
         {
-            var gatewayResponse = _gateway.SearchServices(searchParams);
+            var gatewayResponse = _servicesGateway.SearchServices(searchParams);
             var response = gatewayResponse.ToResponse();
             response.Metadata.PostCode = searchParams.PostCode;
             return response;


### PR DESCRIPTION
# What:
- Get service by id endpoint calculating a straight line distance from each service's service location to the coordinates of an optional user provided postcode.
- Addresses API Gateway used to get the coordinates of the user provided postcode.

# Why:
- Users want to see how far certain service locations shown on the map in front end are when they're considering visiting them.

# Notes:
- Postcode's coordinates are retrieved by getting a list of addresses under the postcode, and taking the coordinates of the first one. There is still an ongoing discussion of whether it should take a single address to represented the postcode, or it should avarage the coordinates of all addresses under the postcode. If it's the latter one minor annoyance would be paging done by addresses api.
- Due to postcode containing multiple properties under it at different coordinate locations, the real distance to service might be different from what's shown. From my testing I found properties under a postcode have varying distance from any target of ~0.3 to ~0.7 miles. Meaning this calculation is only accurate to single digit precision.
- As the postcode is optional, it was decided to make this whole part fail silently if does, including the distance calculation. Under this case corresponding response object fields simply set to null, and the error field bubbles up whatever error message it received.
- This code needs some refactoring that will need to be done later. Reason it wasn't done now is the time constraints - there's no time to try an experiment mocking HttpClient.
- Changed Nullable decimal to Nullable double for Longitude and Latitude response object fields as it's what the GeoLocation library requires as well as it's what Microsoft themselves use for this type of [data](https://docs.microsoft.com/en-us/dotnet/api/system.device.location.geocoordinate.-ctor?view=netframework-4.8#System_Device_Location_GeoCoordinate__ctor).
- Had to change a lot of files due to most of them containing implementation that didn't consider this feature. More information on the commit message of "Implemented calculating distances to service locations from provided".
- I mentioned this already before making a feature and I feel it's approapriate to document this here as well. The distances calculated are straight line distances - in reality they can be much greater due to a person having to take detours around places that can not be crossed.
<p align="center">
<img width="488" alt="Map" src="https://user-images.githubusercontent.com/43747286/94537012-d5027980-023a-11eb-8301-1ed8221a8ee1.png">
</p>
As can be seen from this example the actual walking distance is 2.3 miles, while the straight line one is 1.8 miles, which is 27% higher. Than what would be shown to the user from our service.

Assuming the goal is to give a user a number that represents how far they need to go until they reach the service, I feel it would make more sense to use google maps api to get actual road distance rather than use the current approach. Unless most of our target audience are birds, who can fly in a straight line _(ignoring the wind)_ :)