### PR TITLE
Search encoding fix

### DIFF
--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/SearchServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/SearchServices.cs
@@ -179,5 +179,44 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
             var deserializedBody = JsonConvert.DeserializeObject<GetServiceResponseList>(stringContent);
             deserializedBody.Services.Count.Should().Be(2);
         }
+
+        [TestCase(TestName =
+            "Given that there are services in the database, if a taxonomy only params are provided, services that match are returned")]
+        public async Task GetServicesByTaxonomyParamsReturnServicesIfMatched()
+        {
+            var taxonomy1 = EntityHelpers.CreateTaxonomy();
+            var taxonomy2 = EntityHelpers.CreateTaxonomy();
+            taxonomy1.Vocabulary = "demographic";
+            taxonomy2.Vocabulary = "category";
+            var services = EntityHelpers.CreateServices();
+            var serviceToFind1 = EntityHelpers.CreateService();
+            var serviceToFind2 = EntityHelpers.CreateService();
+            var serviceTaxonomy1 = EntityHelpers.CreateServiceTaxonomy();
+            var serviceTaxonomy2 = EntityHelpers.CreateServiceTaxonomy();
+            var serviceTaxonomy3 = EntityHelpers.CreateServiceTaxonomy();
+            var searchTerm = Randomm.Create<string>();
+            serviceToFind1.Name += searchTerm;
+            serviceToFind2.Name += searchTerm;
+            serviceTaxonomy1.Service = serviceToFind1;
+            serviceTaxonomy1.Taxonomy = taxonomy1;
+            serviceTaxonomy2.Service = serviceToFind1;
+            serviceTaxonomy2.Taxonomy = taxonomy2;
+            serviceTaxonomy3.Service = services.First();
+            serviceTaxonomy3.Taxonomy = taxonomy2;
+            DatabaseContext.Services.AddRange(services);
+            DatabaseContext.Services.Add(serviceToFind1);
+            DatabaseContext.Services.Add(serviceToFind2);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy1);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy2);
+            DatabaseContext.ServiceTaxonomies.Add(serviceTaxonomy3);
+            DatabaseContext.SaveChanges();
+            var requestUri = new Uri($"api/v1/services?taxonomyids={taxonomy1.Id}&taxonomyids={taxonomy2.Id}", UriKind.Relative);
+            var response = Client.GetAsync(requestUri).Result;
+            response.StatusCode.Should().Be(200);
+            var content = response.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(false);
+            var deserializedBody = JsonConvert.DeserializeObject<GetServiceResponseList>(stringContent);
+            deserializedBody.Services.Count.Should().Be(1);
+        }
     }
 }

--- a/LBHFSSPublicAPI/V1/Helpers/UrlHelper.cs
+++ b/LBHFSSPublicAPI/V1/Helpers/UrlHelper.cs
@@ -7,6 +7,8 @@ namespace LBHFSSPublicAPI.V1.Helpers
     {
         public static string DecodeParams(string term)
         {
+            if (string.IsNullOrWhiteSpace(term))
+                return term;
             while (true)
             {
                 var regex = new Regex(@"%20|%25");


### PR DESCRIPTION
- This pull request is to fix an issue where the search endpoint attempts to decode a search parameter that is null.  A null check has been added to the decode helper utility to resolve this issue.
- An additional test for service search has been added for searches that include taxonomy id parameters but not a search parameter.