### PR TITLE
Uprn fix

### DIFF
--- a/LBHFSSPublicAPI.Tests/V1/Domain/ServiceLocationEntityTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Domain/ServiceLocationEntityTests.cs
@@ -91,7 +91,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Domain
         public void ServiceRevisionEntitiesHaveAUprn()
         {
             var entity = new ServiceLocationEntity();
-            var uprn = 100054225;
+            var uprn = "100054225";
             entity.Uprn = uprn;
             entity.Uprn.Should().Be(uprn);
         }

--- a/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -54,7 +54,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
                 domainService.ServiceLocations.Any(sl =>
                     (double?) sl.Latitude == l.Latitude &&
                     (double?) sl.Longitude == l.Longitude &&
-                    sl.Uprn.ToString() == l.Uprn &&
+                    sl.Uprn == l.Uprn &&
                     sl.Address1 == l.Address1 &&
                     sl.Address2 == l.Address2 &&
                     sl.City == l.City &&

--- a/LBHFSSPublicAPI/V1/Domain/ServiceLocationEntity.cs
+++ b/LBHFSSPublicAPI/V1/Domain/ServiceLocationEntity.cs
@@ -16,7 +16,7 @@ namespace LBHFSSPublicAPI.V1.Domain
         //public int RevisionId { get; set; }
 
         public string StateProvince { get; set; }
-        public int? Uprn { get; set; }
+        public string Uprn { get; set; }
         public DateTime? CreatedAt { get; set; }
     }
 }

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201008125957_ChangeUprnToString.Designer.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201008125957_ChangeUprnToString.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20201008125957_ChangeUprnToString")]
+    partial class ChangeUprnToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201008125957_ChangeUprnToString.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201008125957_ChangeUprnToString.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
+{
+    public partial class ChangeUprnToString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "uprn",
+                table: "service_locations",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "uprn",
+                table: "service_locations",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/ServiceLocation.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/ServiceLocation.cs
@@ -8,7 +8,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
         public int? ServiceId { get; set; }
         public decimal? Latitude { get; set; }
         public decimal? Longitude { get; set; }
-        public int? Uprn { get; set; }
+        public string Uprn { get; set; }
         public string Address1 { get; set; }
         public string Address2 { get; set; }
         public string City { get; set; }


### PR DESCRIPTION
## What
An update to the service_locations table in the database, changing the Uprn field from an integer to a varchar data type

## Why
This change addresses an issue raised [here](https://github.com/LBHackney-IT/lbh-fss-public-api/issues/29) where there is a potential for an integer overflow error.

Uprns are stored in our central addresses database as strings, with some, if converted would be larger than what can be stored as a 32 bit integer.

## Note
The Uprn field in the service_locations table will be updated to a varchar datatype on the next db migration.  The relevant entity classes have also been updated from integer data types to string.