### PR TITLE
Feature/get multiple services error handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -134,3 +134,6 @@ dotnet_diagnostic.CA1304.severity = suggestion
 
 # CA1307: Specify StringComparison
 dotnet_diagnostic.CA1307.severity = suggestion
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = suggestion

--- a/LBHFSSPublicAPI.Tests/TestHelpers/ExceptionThrower.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/ExceptionThrower.cs
@@ -1,0 +1,103 @@
+using Bogus;
+using System;
+using System.Collections.Generic;
+
+namespace LBHFSSPublicAPI.Tests.TestHelpers
+{
+    public static class ExceptionThrower
+    {
+        private static int _numberOfCases = 12;
+        private static int _numberOfSimpleCases = 7;
+        private static Faker _faker = new Faker();
+
+        public static Tuple<Exception, List<string>> GenerateExceptionAndCorrespondinExceptionMessages(ExceptionType options = ExceptionType.AnyException)
+        {
+            List<string> exception_messages = new List<string>();
+
+            var random_exception = GenerateException(options);
+
+            try // throw random exception
+            {
+                throw random_exception;
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                exception_messages.Add(ex.Message);
+                exception_messages.Add(ex.InnerException.Message);
+            }
+            catch (Exception ex) // catch the expected exception message
+            {
+                exception_messages.Add(ex.Message);
+            }
+
+            return new Tuple<Exception, List<string>>(random_exception, exception_messages);
+        }
+
+        public static Exception GenerateException(ExceptionType options = ExceptionType.AnyException)
+        {
+            int random_exception_number; // triangulating unexpected exceptions
+
+            switch (options)
+            {
+                case ExceptionType.SimpleException: random_exception_number = _faker.Random.Int(0, _numberOfSimpleCases - 1); break;
+                case ExceptionType.InnerException: random_exception_number = _faker.Random.Int(_numberOfSimpleCases, _numberOfCases - 1); break;
+                default: random_exception_number = _faker.Random.Int(0, _numberOfCases - 1); break;
+            }
+
+            string str = _faker.Random.Hash().ToString(); // triangulating exception messages
+
+            switch (random_exception_number)
+            {
+                case 0: return new OutOfMemoryException(str);
+                case 1: return new IndexOutOfRangeException(str);
+                case 2: return new ArgumentOutOfRangeException(str);
+                case 3: return new MissingFieldException(str);
+                case 4: return new OverflowException(str);
+                case 5: return new TimeoutException(str);
+                case 6: return new StackOverflowException(str);
+                case 7: return GenerateInnerArgumentNullException(str);
+                case 8: return GenerateInnerApplicationException(str);
+                case 9: return GenerateInnerInvalidCastException(str);
+                case 10: return GenerateInnerSystemException(str);
+                default: return GenerateInnerAggregateException(str);
+            }
+        }
+
+        private static SystemException GenerateInnerSystemException(string random_message_addon)
+        {
+            try { throw new SystemException("Inner SystemException exception thrown." + random_message_addon); }
+            catch (SystemException e) { return new SystemException("Outer SystemException exception thrown.", e); }
+        }
+
+        private static InvalidCastException GenerateInnerInvalidCastException(string random_message_addon)
+        {
+            try { throw new InvalidCastException("Inner InvalidCastException exception thrown." + random_message_addon); }
+            catch (InvalidCastException e) { return new InvalidCastException("Outer InvalidCastException exception thrown.", e); }
+        }
+
+        private static ArgumentNullException GenerateInnerArgumentNullException(string random_message_addon)
+        {
+            try { throw new ArgumentNullException("Inner ArgumentNullException exception thrown." + random_message_addon); }
+            catch (ArgumentNullException e) { return new ArgumentNullException("Outer ArgumentNullException exception thrown.", e); }
+        }
+
+        private static ApplicationException GenerateInnerApplicationException(string random_message_addon)
+        {
+            try { throw new ApplicationException("Inner ApplicationException exception thrown." + random_message_addon); }
+            catch (ApplicationException e) { return new ApplicationException("Outer ApplicationException exception thrown.", e); }
+        }
+
+        private static AggregateException GenerateInnerAggregateException(string random_message_addon)
+        {
+            try { throw new AggregateException("Inner AggregateException exception thrown." + random_message_addon); }
+            catch (AggregateException e) { return new AggregateException("Outer AggregateException exception thrown.", e); }
+        }
+
+        public enum ExceptionType
+        {
+            SimpleException,
+            InnerException,
+            AnyException
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using LBHFSSPublicAPI.V1.Boundary;
 using LBHFSSPublicAPI.V1.Boundary.Request;
@@ -34,8 +35,19 @@ namespace LBHFSSPublicAPI.V1.Controllers
         [HttpGet]
         public IActionResult SearchServices([FromQuery] SearchServicesRequest requestParams)
         {
-            var usecaseResult = _servicesUseCase.ExecuteGet(requestParams);
-            return Ok(usecaseResult);
+            try
+            {
+                var usecaseResult = _servicesUseCase.ExecuteGet(requestParams);
+                return Ok(usecaseResult);
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message));
+            }
         }
     }
 }


### PR DESCRIPTION
# What:
- Exception handling for the "Get Multiple Services" endpoint in a Hackney specified way _(custom response object)_.
- Exception thrower test helper.

# Why:
- Added exception handling for an endpoint as it tends to have some data related crashes lately, and we don't see any error messages that would indicate what's wrong.
- Added test helper so that process of implementing error handling for other endpoints would go faster. It also simplifies tests setup a lot, making them more readable.

# Notes:
- <p>Reduced the warning level of CA1031 notification from warning to suggestion. It was done, because the application is configured to fail to compile if there are any warnings. This change is justifiable is because the <a href="https://docs.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1031?view=vs-2019">warning's documentation page</a> says that it's better to leave the performance and similar related errors uncaught because it will aid in debugging.</p><p>In our case, all we're doing is simply reformatting how the exception message will look like <i>(so we're not losing it like it could happen in a more complex error handling scenario)</i>, which means these exceptions do not get lost in the process of error handling, which means we're not in conflict with the reason why CA1031 was introduced. <i>(which was to warn about you potentially programatically ignoring performance related errors)</i></p>