### PR TITLE
A hack of ignoring services who's organization was deleted.

### DIFF
--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -16,6 +16,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
                 .With(s => s.Image, CreateFile)
                 .With(s => s.ServiceTaxonomies, CreateServiceTaxonomies(20)) // Has to be high number to avoid empty collections
                 .With(s => s.ServiceLocations, CreateServiceLocations(5))
+                .With(s => s.Status, "active")                               // Currently hardcoded, as the required fix is temporary hack
                 .Create();
             return service;
         }

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -58,6 +58,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 .Include(s => s.ServiceTaxonomies)
                 .ThenInclude(st => st.Taxonomy)
                 .AsEnumerable()
+                .Where(s => s.Status == "active")
                 .Where(x => synonyms.Count == 0 || synonyms.Any(b => x.Name.ToUpper().Contains(b)))
                 .Where(x => demographicTaxonomies == null || demographicTaxonomies.Count == 0
                                                           || x.ServiceTaxonomies.Any(st => demographicTaxonomies.Contains(st.TaxonomyId)))


### PR DESCRIPTION
# What:
- A filter for ignoring all but "active" services.

# Why:
- <p>At this point in time the Portal API's DELETE an organisation endpoint removes an organisation from the database, and sets all the organisation id's of related services to null. This results in the database containing such orphan services with no related organisation.</p><p>It was discovered that when the Public (this) API does a query to get all the services, it crashes upon trying to retrieve a collection of services that contains a service related to an organisation, which doesn't exist.</p><p>So the fix is done on the Public API rather than Portal API because it's unclear whether that's the intended DELETE organisation endpoint's behaviour. While we're waiting for an answer, this fix will do.</p>

# Notes:
- Within the tests I didn't do the equivalence check assertion, as '.BeEquivalentTo' method from FluentAssertions has a very buggy implementation. Upon checking the equivalence of the object graph in question, it fails with "Maximum recursion depth was reached". And upon passing in the 'AllowingInfiniteRecursion' option, it simply keeps on running forever, which makes sense. However once you try to disable the recursion with 'IgnoringCyclicReferences', it does nothing, even though, the issue quite clearly comes from cyclic references. Not only that 'ExcludingNestedObjects' doesn't work either, the recursion somehow happens anyway, even though, we're ignoring nested objects, which are the only things you can recurse to.
- Naming this a hack so it would be easier to find in the future if there is a need to change these changes back. It's also fitting because we're treating the symptom rather than the cause, on the basis of that we can't wait for business logic answer, which is unfortunate.