### PR TITLE
Changed entity deletion behaviour

### DIFF
--- a/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
@@ -225,6 +225,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                 entity.HasOne(d => d.Service)
                     .WithMany(p => p.ServiceLocations)
                     .HasForeignKey(d => d.ServiceId)
+                    .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("service_locations_service_id_fkey");
             });
 
@@ -245,6 +246,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                 entity.HasOne(d => d.Service)
                     .WithMany(p => p.ServiceTaxonomies)
                     .HasForeignKey(d => d.ServiceId)
+                    .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("service_taxonomies_service_id_fkey");
 
                 entity.HasOne(d => d.Taxonomy)
@@ -327,6 +329,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                 entity.HasOne(d => d.Organization)
                     .WithMany(p => p.Services)
                     .HasForeignKey(d => d.OrganizationId)
+                    .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("services_organization_id_fkey");
             });
 

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102121409_AddDeleteConstraintsToServices.Designer.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102121409_AddDeleteConstraintsToServices.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20201102121409_AddDeleteConstraintsToServices")]
+    partial class AddDeleteConstraintsToServices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -616,8 +618,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
                     b.HasOne("LBHFSSPublicAPI.V1.Infrastructure.Organization", "Organization")
                         .WithMany("Services")
                         .HasForeignKey("OrganizationId")
-                        .HasConstraintName("services_organization_id_fkey")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .HasConstraintName("services_organization_id_fkey");
                 });
 
             modelBuilder.Entity("LBHFSSPublicAPI.V1.Infrastructure.ServiceLocation", b =>

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102121409_AddDeleteConstraintsToServices.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102121409_AddDeleteConstraintsToServices.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
+{
+    public partial class AddDeleteConstraintsToServices : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "service_locations_service_id_fkey",
+                table: "service_locations");
+
+            migrationBuilder.AddForeignKey(
+                name: "service_locations_service_id_fkey",
+                table: "service_locations",
+                column: "service_id",
+                principalTable: "services",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "service_locations_service_id_fkey",
+                table: "service_locations");
+
+            migrationBuilder.AddForeignKey(
+                name: "service_locations_service_id_fkey",
+                table: "service_locations",
+                column: "service_id",
+                principalTable: "services",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102142706_AddDeleteConstraintsToOrgnisations.Designer.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102142706_AddDeleteConstraintsToOrgnisations.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20201102142706_AddDeleteConstraintsToOrgnisations")]
+    partial class AddDeleteConstraintsToOrgnisations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102142706_AddDeleteConstraintsToOrgnisations.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20201102142706_AddDeleteConstraintsToOrgnisations.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
+{
+    public partial class AddDeleteConstraintsToOrgnisations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "services_organization_id_fkey",
+                table: "services");
+
+            migrationBuilder.AddForeignKey(
+                name: "services_organization_id_fkey",
+                table: "services",
+                column: "organization_id",
+                principalTable: "organizations",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "services_organization_id_fkey",
+                table: "services");
+
+            migrationBuilder.AddForeignKey(
+                name: "services_organization_id_fkey",
+                table: "services",
+                column: "organization_id",
+                principalTable: "organizations",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
## What
Changed the delete behaviour of services and organisations to ensure relevant related entities are also deleted.

## Why
When organisations are deleted, related services and their service locations and taxonomies need to be deleted as well, otherwise there will be orphaned services without linked organisations in the database which causes an error when attempting to list or view a service that has a null value for its organisation.

## Note
This PR does not change any implementation in the API but only changes the database implementation