### PR TITLE
Upgrade/more fuzzy search

### DIFF
--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -31,5 +31,6 @@
   <ItemGroup>
     <Folder Include="TestHelpers\" />
     <Folder Include="V1\Boundary\" />
+    <Folder Include="V1\Boundary\HelperWrappers\" />
   </ItemGroup>
 </Project>

--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -136,7 +136,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             return taxonomies;
         }
 
-        public static ICollection<Service> CreateServices(int count = 3)
+        public static List<Service> CreateServices(int count = 3)
         {
             var services = new List<Service>();
             for (var a = 0; a < count; a++)

--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -177,6 +177,15 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             return synonymGroup;
         }
 
+        public static SynonymWord SynWord(SynonymGroup synGroup, string word) // do I need to set the synonym group, or will id suffice?
+        {
+            return new SynonymWord()
+            {
+                GroupId = synGroup.Id,
+                Word = word
+            };
+        }
+
 
         // public static UserRole CreateUserRole()
         // {

--- a/LBHFSSPublicAPI.Tests/TestHelpers/FactoryHelper.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/FactoryHelper.cs
@@ -13,7 +13,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             if (entities == null)
                 return new List<ServiceEntity>();
-            
+
             return entities.Select(e => e.ToDomain()).ToList();
         }
     }

--- a/LBHFSSPublicAPI.Tests/TestHelpers/FactoryHelper.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/FactoryHelper.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LBHFSSPublicAPI.V1.Domain;
+using LBHFSSPublicAPI.V1.Factories;
+using Entity = LBHFSSPublicAPI.V1.Infrastructure;
+
+namespace LBHFSSPublicAPI.Tests.TestHelpers
+{
+    public static class FactoryHelper
+    {
+        public static List<ServiceEntity> ToDomain(this List<Entity.Service> entities)
+        {
+            if (entities == null)
+                return new List<ServiceEntity>();
+            
+            return entities.Select(e => e.ToDomain()).ToList();
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -38,6 +38,10 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             return string.Join(" ", _faker.Random.Words(5));
         }
+        public static T RandomItem<T>(this ICollection<T> collection )
+        {
+            return _faker.Random.CollectionItem(collection);
+        }
         public static T Create<T>()
         {
             return _fixture.Create<T>();

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -33,7 +33,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         }
         public static string Word()
         {
-            return _faker.Random.Word().Replace(" ", ""); // sometimes it generates multiple words like "face to face";
+            return _faker.Random.Hash().ToString(); // .Word() had too many problems: sometimes less than 3 chars, sometimes more than 1 word.
         }
         public static string Text()
         {

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -33,7 +33,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         }
         public static string Word()
         {
-            return _faker.Random.Word();
+            return _faker.Random.Word().Replace(" ", ""); // sometimes it generates multiple words like "face to face";
         }
         public static string Text()
         {

--- a/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/Randomm.cs
@@ -7,6 +7,7 @@ using AutoFixture.Dsl;
 using AutoFixture.Kernel;
 using Bogus;
 using Geolocation;
+using LBHFSSPublicAPI.V1.Boundary.HelperWrappers;
 using LBHFSSPublicAPI.V1.Domain;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using LBHFSSPublicAPI.V1.Infrastructure.AddressesContextEntities;
@@ -38,7 +39,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             return string.Join(" ", _faker.Random.Words(5));
         }
-        public static T RandomItem<T>(this ICollection<T> collection )
+        public static T RandomItem<T>(this ICollection<T> collection)
         {
             return _faker.Random.CollectionItem(collection);
         }
@@ -87,6 +88,18 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             return _faker.Address.ZipCode();
         }
+
+        #region ComplexTypes
+
+        public static SearchServiceGatewayResult SSGatewayResult()
+        {
+            return new SearchServiceGatewayResult(
+                    EntityHelpers.CreateServices(_faker.Random.Int(5, 10)).ToDomain(),
+                    EntityHelpers.CreateServices(_faker.Random.Int(5, 10)).ToDomain()
+                );
+        }
+
+        #endregion
 
         #region Addresses API Fake Response
 

--- a/LBHFSSPublicAPI.Tests/TestHelpers/UtilityHelper.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/UtilityHelper.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace LBHFSSPublicAPI.Tests.TestHelpers
+{
+    public static class Utility
+    {
+        public static string SuperSetOfString(string text)
+        {
+            var surroundText = Randomm.Word();
+            var midpoint = (int) Math.Ceiling((decimal) surroundText.Length / 2);
+            return surroundText.Insert(midpoint, text);
+        }
+
+        public static void AddMany<T>(this List<T> list, params T[] elements)
+        {
+            list.AddRange(elements);
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/V1/Boundary/HelperWrappers/SearchServiceGatewayResultTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Boundary/HelperWrappers/SearchServiceGatewayResultTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using LBHFSSPublicAPI.Tests.TestHelpers;
+using LBHFSSPublicAPI.V1.Boundary.HelperWrappers;
+using LBHFSSPublicAPI.V1.Domain;
+using NUnit.Framework;
+
+namespace LBHFSSPublicAPI.Tests.V1.Boundary.HelperWrappers
+{
+    [TestFixture]
+    public class SearchServiceGatewayResultTests
+    {
+        [Test]
+        public void SearchServiceGatewayResultObjectShouldHaveCorrectProperties()
+        {
+            // arrange
+            var wrapperType = typeof(SearchServiceGatewayResult);
+            var expectedServicesType = typeof(List<ServiceEntity>);
+
+            // act
+            var entity = Randomm.Create<SearchServiceGatewayResult>();
+
+            // assert
+            wrapperType.GetProperties().Length.Should().Be(2);
+
+            Assert.That(entity, Has.Property("TaxonomyIds").InstanceOf(expectedServicesType));
+            Assert.That(entity, Has.Property("PostCode").InstanceOf(expectedServicesType));
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/V1/Boundary/HelperWrappers/SearchServiceGatewayResultTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Boundary/HelperWrappers/SearchServiceGatewayResultTests.cs
@@ -24,8 +24,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Boundary.HelperWrappers
             // assert
             wrapperType.GetProperties().Length.Should().Be(2);
 
-            Assert.That(entity, Has.Property("TaxonomyIds").InstanceOf(expectedServicesType));
-            Assert.That(entity, Has.Property("PostCode").InstanceOf(expectedServicesType));
+            Assert.That(entity, Has.Property("FullMatchServices").InstanceOf(expectedServicesType));
+            Assert.That(entity, Has.Property("SplitMatchServices").InstanceOf(expectedServicesType));
         }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -1,9 +1,11 @@
 using FluentAssertions;
 using LBHFSSPublicAPI.Tests.TestHelpers;
+using Response = LBHFSSPublicAPI.V1.Boundary.Response;
 using LBHFSSPublicAPI.V1.Domain;
 using LBHFSSPublicAPI.V1.Factories;
 using NUnit.Framework;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace LBHFSSPublicAPI.Tests.V1.Factories
 {
@@ -79,6 +81,9 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             responseService.Status.Should().Be(domainService.Status);
         }
 
+        // No need to test the ToResponseServices (Converting List of domain to List of Reponse) because it's a basic Linq query consisting of
+        // 1 Select statement. At that point, it would be a test of Microsoft's 'Select' implementation rather than a test of a method (due to it being a wrapper)
+
         [TestCase(TestName = "Given a service domain object, When Factory ToResponse extension method is called, Then it returns correctly populated GetServiceResponse boundary object.")]
         public void FactoryConvertsServiceDomainToGetServiceResponseBoundary()
         {
@@ -97,22 +102,58 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             responseBoundary.Metadata.PostCodeLongitude.Should().BeNull();
         }
 
-        [TestCase(TestName = "Given a list of service domain objects, When Factory ToResponse extension method is called, Then it returns correctly populated GetServiceResponseList boundary object.")]
-        public void FactoryConvertsAListOfServiceDomainToGetServiceResponseListBoundary()
+        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with those 2 lists concatinated AND metadata fields set to null.")]
+        public void FactoryConverts2NonEmptyListOfServiceResponseToGetServiceResponseListBoundary()
         {
             // arrange
-            var domainServices = EntityHelpers.CreateServices().ToDomain(); // would need domain generator, but domain object is messed up now.
-            var expectedServices = domainServices.Select(ds => ds.ToResponseService()).ToList();
+            var gatewayResponse = Randomm.SSGatewayResult();
+            var fullMatchServices = gatewayResponse.FullMatchServices.ToResponseServices();
+            var splitMatchServices = gatewayResponse.SplitMatchServices.ToResponseServices();
+
+            var expectedServicesList = fullMatchServices.Concat(splitMatchServices);
 
             // act
-            var responseBoundary = domainServices.ToResponse();
+            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, splitMatchServices);
 
             // assert
-            responseBoundary.Services.Should().BeEquivalentTo(expectedServices);
-            responseBoundary.Metadata.Error.Should().BeNull();
-            responseBoundary.Metadata.PostCode.Should().BeNull();
-            responseBoundary.Metadata.PostCodeLatitude.Should().BeNull();
-            responseBoundary.Metadata.PostCodeLongitude.Should().BeNull();
+            factoryResult.Services.Should().BeEquivalentTo(expectedServicesList);
+            factoryResult.Metadata.Error.Should().BeNull();
+            factoryResult.Metadata.PostCode.Should().BeNull();
+            factoryResult.Metadata.PostCodeLatitude.Should().BeNull();
+            factoryResult.Metadata.PostCodeLongitude.Should().BeNull();
+        }
+
+        [TestCase(TestName = "Given 1 empty and 1 non-empty list of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with a list containing all the elements from the non-empty list.")] // essentially a check that it doesn't fall over under these circumstances
+        public void FactoryConverts1EmptyAnd1NonEmptyListOfServiceResponseToGetServiceResponseListBoundary()
+        {
+            // arrange
+            var gatewayResponse = Randomm.SSGatewayResult();
+            var fullMatchServices = gatewayResponse.FullMatchServices.ToResponseServices();
+            var splitMatchServices = gatewayResponse.SplitMatchServices.ToResponseServices();
+            var emptyList = new List<Response.Service>();
+
+            // act
+            var factoryResult1 = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, emptyList);
+            var factoryResult2 = ServiceFactory.SearchServiceUsecaseResponse(emptyList, splitMatchServices);
+
+            // assert
+            factoryResult1.Services.Should().BeEquivalentTo(fullMatchServices);
+            factoryResult2.Services.Should().BeEquivalentTo(splitMatchServices);
+        }
+
+        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with those 2 lists concatinated AND metadata fields set to null.")] // essentially a check that it doesn't fall over under these circumstances
+        public void FactoryConverts2EmptyListOfServiceResponseToGetServiceResponseListBoundary()
+        {
+            // arrange
+            var emptyList1 = new List<Response.Service>();
+            var emptyList2 = new List<Response.Service>();
+            var emptyList3 = new List<Response.Service>();                                  // for the sake of different object refs
+
+            // act
+            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(emptyList1, emptyList2);
+
+            // assert
+            factoryResult.Services.Should().BeEquivalentTo(emptyList3);
         }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -6,6 +6,8 @@ using LBHFSSPublicAPI.V1.Factories;
 using NUnit.Framework;
 using System.Linq;
 using System.Collections.Generic;
+using LBHFSSPublicAPI.V1.Boundary.Response;
+using System;
 
 namespace LBHFSSPublicAPI.Tests.V1.Factories
 {
@@ -102,7 +104,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             responseBoundary.Metadata.PostCodeLongitude.Should().BeNull();
         }
 
-        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with those 2 lists concatinated AND metadata fields set to null.")]
+        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with those 2 lists concatinated.")]
         public void FactoryConverts2NonEmptyListOfServiceResponseToGetServiceResponseListBoundary()
         {
             // arrange
@@ -113,14 +115,10 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             var expectedServicesList = fullMatchServices.Concat(splitMatchServices);
 
             // act
-            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, splitMatchServices);
+            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, splitMatchServices, null);
 
             // assert
             factoryResult.Services.Should().BeEquivalentTo(expectedServicesList);
-            factoryResult.Metadata.Error.Should().BeNull();
-            factoryResult.Metadata.PostCode.Should().BeNull();
-            factoryResult.Metadata.PostCodeLatitude.Should().BeNull();
-            factoryResult.Metadata.PostCodeLongitude.Should().BeNull();
         }
 
         [TestCase(TestName = "Given 1 empty and 1 non-empty list of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with a list containing all the elements from the non-empty list.")] // essentially a check that it doesn't fall over under these circumstances
@@ -133,15 +131,15 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             var emptyList = new List<Response.Service>();
 
             // act
-            var factoryResult1 = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, emptyList);
-            var factoryResult2 = ServiceFactory.SearchServiceUsecaseResponse(emptyList, splitMatchServices);
+            var factoryResult1 = ServiceFactory.SearchServiceUsecaseResponse(fullMatchServices, emptyList, null);
+            var factoryResult2 = ServiceFactory.SearchServiceUsecaseResponse(emptyList, splitMatchServices, null);
 
             // assert
             factoryResult1.Services.Should().BeEquivalentTo(fullMatchServices);
             factoryResult2.Services.Should().BeEquivalentTo(splitMatchServices);
         }
 
-        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with those 2 lists concatinated AND metadata fields set to null.")] // essentially a check that it doesn't fall over under these circumstances
+        [TestCase(TestName = "Given 2 non-empty lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with an empty services list.")] // essentially a check that it doesn't fall over under these circumstances
         public void FactoryConverts2EmptyListOfServiceResponseToGetServiceResponseListBoundary()
         {
             // arrange
@@ -150,10 +148,75 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
             var emptyList3 = new List<Response.Service>();                                  // for the sake of different object refs
 
             // act
-            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(emptyList1, emptyList2);
+            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(emptyList1, emptyList2, null);
 
             // assert
             factoryResult.Services.Should().BeEquivalentTo(emptyList3);
+        }
+
+        [TestCase(TestName = "Given any combination of null lists of service response objects, When Factory SearchServiceUsecaseResponse method is called, Then it returns a GetServiceResponseList boundary object with an empty services list.")] // essentially a check that it doesn't fall over under these circumstances
+        public void FactoryDoesNotCrashWhenGivenNullListsAndInsteadReturnsExpectedResult()
+        {
+            // arrange
+            var nullList = null as List<Response.Service>;
+
+            var emptyList = new List<Response.Service>();
+            var emptyListC = new List<Response.Service>();                                  // for the sake of different object refs
+
+            var notEmptyList = new List<Response.Service> { new Service() };
+            var notEmptyListC = new List<Response.Service> { new Service() };
+
+            Func<GetServiceResponseList> firstArgNull = () => ServiceFactory.SearchServiceUsecaseResponse(nullList, emptyList, null);
+            Func<GetServiceResponseList> secondArgNull = () => ServiceFactory.SearchServiceUsecaseResponse(emptyList, nullList, null);
+            Func<GetServiceResponseList> bothArgsNull = () => ServiceFactory.SearchServiceUsecaseResponse(nullList, nullList, null);
+
+            Func<GetServiceResponseList> nullNotEmpty = () => ServiceFactory.SearchServiceUsecaseResponse(nullList, notEmptyList, null);
+            Func<GetServiceResponseList> notEmptyNull = () => ServiceFactory.SearchServiceUsecaseResponse(notEmptyList, nullList, null);
+
+            // act
+            var factoryResult1 = firstArgNull.Invoke();
+            var factoryResult2 = secondArgNull.Invoke();
+            var factoryResult3 = bothArgsNull.Invoke();
+
+            var factoryResult4 = nullNotEmpty.Invoke();
+            var factoryResult5 = notEmptyNull.Invoke();
+
+            // assert
+            firstArgNull.Should().NotThrow<ArgumentNullException>();
+            secondArgNull.Should().NotThrow<ArgumentNullException>();
+            bothArgsNull.Should().NotThrow<ArgumentNullException>();
+
+            nullNotEmpty.Should().NotThrow<ArgumentNullException>();
+            notEmptyNull.Should().NotThrow<ArgumentNullException>();
+
+            factoryResult1.Services.Should().BeEquivalentTo(emptyListC);
+            factoryResult2.Services.Should().BeEquivalentTo(emptyListC);
+            factoryResult3.Services.Should().BeEquivalentTo(emptyListC);
+
+            factoryResult4.Services.Should().BeEquivalentTo(notEmptyListC);
+            factoryResult5.Services.Should().BeEquivalentTo(notEmptyListC);
+        }
+
+        [TestCase()]
+        public void FactoryPopulatesTheMetadataFieldWithWhatIsPassedInAsAnArgument()
+        {
+            // arrange
+            var expectedMetadata = new Metadata
+            {
+                Error = Randomm.Text(),
+                PostCode = Randomm.Postcode(),
+                PostCodeLatitude = Randomm.Latitude(),
+                PostCodeLongitude = Randomm.Longitude()
+            };
+
+            // act
+            var factoryResult = ServiceFactory.SearchServiceUsecaseResponse(null, null, expectedMetadata);
+
+            // assert
+            factoryResult.Metadata.Error.Should().Be(expectedMetadata.Error);
+            factoryResult.Metadata.PostCode.Should().Be(expectedMetadata.PostCode);
+            factoryResult.Metadata.PostCodeLatitude.Should().Be(expectedMetadata.PostCodeLatitude);
+            factoryResult.Metadata.PostCodeLongitude.Should().Be(expectedMetadata.PostCodeLongitude);
         }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -121,6 +121,82 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             returnedServices.Count.Should().Be(10);
         }
 
+        [TestCase(TestName = "Given user search input That does not have a match But its split part's synonym does, When SearchService gateway method is called, Then it returns records matching related synonym group And stored under splitMatchServices field.")]
+        public void EvenIfWholeOrSplitUserInputDoesNotHaveAMatchThenSplitInputSynonymMatchesAreReturned()
+        {
+            // arrange
+            var searchWord1 = Randomm.Word();                            // word that won't match any results, however 1 of its synonyms from synonym group will
+            var searchWord2 = Randomm.Word();                            // same as above, but the matching synonym will be in another synonym group
+            var irrelevantWord = Randomm.Word();                         // a control word, that won't match anything, nor its synonyms will.
+
+            var userInput = $"{searchWord1} "
+                          + $"{irrelevantWord} "
+                          + $"{searchWord2}";
+
+            var request = new SearchServicesRequest();
+            request.Search = userInput;
+
+            var bridgeSyn1Word = Utility.SuperSetOfString(searchWord1);     // A superset word of search word 1 that will relate to a synonym word inside synonym group 1 - this word has no match in the DB
+            var bridgeSyn2Word = Utility.SuperSetOfString(searchWord2);     // A superset word of search word 2 that will relate to a synonym word inside synonym group 2 - this word has no match in the DB
+
+
+            var synWord1 = Randomm.Word();                            // synonym within the same synonym group (1) as a word related to search word 1 - this word has a match in the DB
+            var synWord2 = Randomm.Word();                            // synonym within the same synonym group (1) as a word related to search word 1 - this word has a match in the DB
+            var synWord3 = Randomm.Word();                            // synonym within the same synonym group (2) as a word related to search word 2 - this word has a match in the DB
+
+
+            var synonymGroup1 = EntityHelpers.CreateSynonymGroupWithWords();            // relevant group with dummy synonym words
+            var synonymGroup2 = EntityHelpers.CreateSynonymGroupWithWords();            // relevant group with dummy synonym words
+            var dummySynGroup = EntityHelpers.CreateSynonymGroupWithWords();            // dummy synonym group that should not be picked up
+
+            var bridgeSynonym1 = EntityHelpers.SynWord(synonymGroup1, bridgeSyn1Word);  // synonym that has no match in DB, however it bridges user input search word with the synonym group 1
+            var bridgeSynonym2 = EntityHelpers.SynWord(synonymGroup2, bridgeSyn2Word);
+
+            var matchSynonym1 = EntityHelpers.SynWord(synonymGroup1, synWord1);         // creating a synonym word object to insert that will have a match, creating a link with synonym group 1
+            var matchSynonym2 = EntityHelpers.SynWord(synonymGroup1, synWord2);
+            var matchSynonym3 = EntityHelpers.SynWord(synonymGroup2, synWord3);
+
+
+            synonymGroup1.SynonymWords.Add(bridgeSynonym1);                  // added bridge synonym to the synonym group
+            synonymGroup2.SynonymWords.Add(bridgeSynonym2);
+
+            synonymGroup1.SynonymWords.Add(matchSynonym1);                   // added match synonym into a synonym group
+            synonymGroup1.SynonymWords.Add(matchSynonym2);
+            synonymGroup2.SynonymWords.Add(matchSynonym3);
+
+
+            var services = EntityHelpers.CreateServices(5);                  // creating list of dummy services that should not be found
+
+            var matchService1 = EntityHelpers.CreateService();               // service that is intended to be found through the synonym of synonym group 1
+            var matchService2 = EntityHelpers.CreateService();               // service that is intended to be found through the synonym of synonym group 1
+            var matchService3 = EntityHelpers.CreateService();               // service that is intended to be found through the synonym of synonym group 2
+
+            matchService1.Name += synWord1;                                  // creating a link between a service and a match synonym 1
+            matchService2.Name += synWord2;                                  // creating a link between a service and a match synonym 2
+            matchService3.Name += synWord3;                                  // creating a link between a service and a match synonym 3
+
+            services.AddMany(matchService1, matchService2, matchService3);   // include match services into a to be inserted services collection
+
+            DatabaseContext.SynonymGroups.AddRange(synonymGroup1);           // adding synonym groups containing synonym words into a database
+            DatabaseContext.SynonymGroups.AddRange(synonymGroup2);
+            DatabaseContext.SynonymGroups.AddRange(dummySynGroup);
+            DatabaseContext.Services.AddRange(services);                     // adding services into a database
+
+            DatabaseContext.SaveChanges();
+
+            // act
+            var gatewayResult = _classUnderTest.SearchServices(request);
+            var splitMatches = gatewayResult.SplitMatchServices;
+            var fullMatches = gatewayResult.FullMatchServices;
+
+            // assert
+            splitMatches.Should().Contain(s => s.Name.Contains(synWord1));
+            splitMatches.Should().Contain(s => s.Name.Contains(synWord2));
+            splitMatches.Should().Contain(s => s.Name.Contains(synWord3));
+            splitMatches.Should().HaveCount(3);
+            fullMatches.Should().HaveCount(0);
+        }
+
         [TestCase(TestName = "Given search parameters when the SearchService method is called it returns records matching applied synonym group")]
         public void GivenSearchParametersWhenSearchServicesGatewayMethodIsCalledThenItReturnsMatchingSynonymGroupResults()
         {

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -257,11 +257,14 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             var request = new SearchServicesRequest() { Search = userSearchInput };
 
             var services = EntityHelpers.CreateServices(5).ToList();                // dummy services
+            services.ForEach(s => s.Name = s.Name.Replace(word, "ssj"));            // make sure they don't match the search word
                                                                                     // assuming there's no full match. due to full match containing a shortword, the assertion at the bottom wouldn't be able to test what's needed.
             var serviceToFind = EntityHelpers.CreateService();                      // word 1 match
             serviceToFind.Name = serviceToFind.Name.Replace(shortWord, "test");     // ensuring random hash does not contain shortword. for the assertion bellow to work as intended, the service name's hash part should not contain shortword.
             serviceToFind.Name += word;
+
             var serviceToNotFind = EntityHelpers.CreateService();                   // shortword no match. this ensures that the test can fail if the implementation is wrong or not present.
+            serviceToNotFind.Name = serviceToNotFind.Name.Replace(word, "1234");    // make sure the mismatching service does not contain a desired search term
             serviceToNotFind.Name += shortWord;
 
             services.Add(serviceToFind);

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -129,6 +129,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             var synonymGroup2 = EntityHelpers.CreateSynonymGroupWithWords(3);
             synonymGroup2.SynonymWords.ToList()[1].Word = synonymGroup1.SynonymWords.ToList()[1].Word;
             var services = EntityHelpers.CreateServices();
+            services.ForEach(s => s.Name = "irrelenvant");
             var serviceToFind1 = EntityHelpers.CreateService();
             var serviceToFind2 = EntityHelpers.CreateService();
             var searchTerm = synonymGroup1.SynonymWords.ToList()[1].Word;

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -31,6 +31,7 @@
     <Folder Include="V1\Exceptions\" />
     <Folder Include="V1\Infrastructure\AddressesContextEntities\" />
     <Folder Include="V1\Domain\AddressesAPIDomain\" />
+    <Folder Include="V1\Boundary\HelperWrappers\" />
   </ItemGroup>
 
 </Project>

--- a/LBHFSSPublicAPI/V1/Boundary/HelperWrappers/SearchServiceGatewayResult.cs
+++ b/LBHFSSPublicAPI/V1/Boundary/HelperWrappers/SearchServiceGatewayResult.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using LBHFSSPublicAPI.V1.Domain;
+
+namespace LBHFSSPublicAPI.V1.Boundary.HelperWrappers
+{
+    public class SearchServiceGatewayResult
+    {
+        public List<ServiceEntity> FullMatchServices { get; set; }  // higher relevance
+        public List<ServiceEntity> SplitMatchServices { get; set; } // lower relevance
+
+        public SearchServiceGatewayResult(List<ServiceEntity> fullMatchServices, List<ServiceEntity> splitMatchServices)
+        {
+            FullMatchServices = fullMatchServices;
+            SplitMatchServices = splitMatchServices;
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Boundary/Response/GetServicesResponseList.cs
+++ b/LBHFSSPublicAPI/V1/Boundary/Response/GetServicesResponseList.cs
@@ -6,5 +6,13 @@ namespace LBHFSSPublicAPI.V1.Boundary.Response
     {
         public List<Service> Services { get; set; }
         public Metadata Metadata { get; set; }
+
+        public GetServiceResponseList() { }
+
+        public GetServiceResponseList(List<Service> services, Metadata metadata)
+        {
+            Services = services;
+            Metadata = metadata;
+        }
     }
 }

--- a/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
+++ b/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
@@ -32,24 +32,25 @@ namespace LBHFSSPublicAPI.V1.Factories
                 return null;
         }
 
-        public static GetServiceResponseList ToResponse(this ICollection<ServiceEntity> serviceDomainList)
+        public static GetServiceResponseList SearchServiceUsecaseResponse(List<Response.Service> fullMatches, List<Response.Service> splitMatches)
         {
-            if (serviceDomainList != null)
-                return new GetServiceResponseList()
-                {
-                    Services = serviceDomainList
-                        .Select(s => s.ToResponseService())
-                        .ToList(),
-                    Metadata = new Metadata
-                    {
-                        PostCode = null,
-                        PostCodeLatitude = null,
-                        PostCodeLongitude = null,
-                        Error = null
-                    }
-                };
-            else
-                return new GetServiceResponseList();
+            var metadata = new Metadata
+            {
+                PostCode = null,
+                PostCodeLatitude = null,
+                PostCodeLongitude = null,
+                Error = null
+            };
+
+            var combinedServicesList = new List<Response.Service>();
+
+            if (fullMatches != null)
+                combinedServicesList.AddRange(fullMatches);
+
+            if (splitMatches != null)
+                combinedServicesList.AddRange(splitMatches);
+
+            return new GetServiceResponseList(combinedServicesList, metadata);
         }
 
         #endregion
@@ -84,6 +85,11 @@ namespace LBHFSSPublicAPI.V1.Factories
 
                 Status = serviceDomain.Status
             };
+        }
+
+        public static List<Response.Service> ToResponseServices(this List<ServiceEntity> collection)
+        {
+            return collection.Select(s => s.ToResponseService()).ToList();
         }
 
         private static List<Category> ToResponseCategoryList(this ICollection<ServiceTaxonomy> serviceTaxonomies)
@@ -234,13 +240,6 @@ namespace LBHFSSPublicAPI.V1.Factories
                 ReferralEmail = entity.ReferralEmail,
                 ReferralLink = entity.ReferralLink
             };
-        }
-
-        public static ICollection<ServiceEntity> ToDomain(this ICollection<Entity.Service> entities)
-        {
-            if (entities == null)
-                return new List<ServiceEntity>();
-            return entities.Select(e => e.ToDomain()).ToList();
         }
 
         #endregion

--- a/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
+++ b/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
@@ -32,16 +32,8 @@ namespace LBHFSSPublicAPI.V1.Factories
                 return null;
         }
 
-        public static GetServiceResponseList SearchServiceUsecaseResponse(List<Response.Service> fullMatches, List<Response.Service> splitMatches)
+        public static GetServiceResponseList SearchServiceUsecaseResponse(List<Response.Service> fullMatches, List<Response.Service> splitMatches, Metadata metadata)
         {
-            var metadata = new Metadata
-            {
-                PostCode = null,
-                PostCodeLatitude = null,
-                PostCodeLongitude = null,
-                Error = null
-            };
-
             var combinedServicesList = new List<Response.Service>();
 
             if (fullMatches != null)

--- a/LBHFSSPublicAPI/V1/Gateways/Interfaces/IServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/Interfaces/IServicesGateway.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using LBHFSSPublicAPI.V1.Boundary.HelperWrappers;
 using LBHFSSPublicAPI.V1.Boundary.Request;
 using LBHFSSPublicAPI.V1.Domain;
 
@@ -8,6 +9,6 @@ namespace LBHFSSPublicAPI.V1.Gateways.Interfaces
     public interface IServicesGateway
     {
         ServiceEntity GetService(int id);
-        ICollection<ServiceEntity> SearchServices(SearchServicesRequest requestParams);
+        SearchServiceGatewayResult SearchServices(SearchServicesRequest requestParams);
     }
 }

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using LBHFSSPublicAPI.V1.Boundary.HelperWrappers;
 using LBHFSSPublicAPI.V1.Boundary.Request;
 using LBHFSSPublicAPI.V1.Domain;
 using LBHFSSPublicAPI.V1.Factories;
@@ -31,7 +32,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
             return service;
         }
 
-        public ICollection<ServiceEntity> SearchServices(SearchServicesRequest requestParams)
+        public SearchServiceGatewayResult SearchServices(SearchServicesRequest requestParams)
         {
             var synonyms = new HashSet<string>();
             var demographicTaxonomies = _context.Taxonomies
@@ -74,7 +75,8 @@ namespace LBHFSSPublicAPI.V1.Gateways
                                                           || s.ServiceTaxonomies.Any(st => categoryTaxonomies.Contains(st.TaxonomyId)))
                 .Select(s => s.ToDomain())
                 .ToList();
-            return services;
+
+            return new SearchServiceGatewayResult(services, new List<ServiceEntity>());
         }
     }
 }

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -42,8 +42,14 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 .Select(t => t.Id).ToList();
             if (!string.IsNullOrWhiteSpace(requestParams.Search))
             {
-                synonyms.Add(requestParams.Search.ToUpper());
-                var matchedSynonyms = _context.SynonymWords
+                var searchInputText = requestParams.Search.ToUpper();
+                var keywords = searchInputText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                keywords.Append(searchInputText);           // the concatinated value might be in the synonyms database
+
+                foreach (var keyword in keywords)
+                    synonyms.Add(keyword);
+
+                var matchedSynonyms = _context.SynonymWords // This variable is not being used! Does it even need to be here?
                     .Include(sw => sw.Group)
                     .ThenInclude(sg => sg.SynonymWords)
                     .Where(x => x.Word.ToUpper().Contains(requestParams.Search.ToUpper()))
@@ -59,11 +65,11 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 .ThenInclude(st => st.Taxonomy)
                 .AsEnumerable()
                 .Where(s => s.Status == "active")
-                .Where(x => synonyms.Count == 0 || synonyms.Any(b => x.Name.ToUpper().Contains(b)))
-                .Where(x => demographicTaxonomies == null || demographicTaxonomies.Count == 0
-                                                          || x.ServiceTaxonomies.Any(st => demographicTaxonomies.Contains(st.TaxonomyId)))
-                .Where(x => categoryTaxonomies == null || categoryTaxonomies.Count == 0
-                                                          || x.ServiceTaxonomies.Any(st => categoryTaxonomies.Contains(st.TaxonomyId)))
+                .Where(s => synonyms.Count == 0 || synonyms.Any(b => s.Name.ToUpper().Contains(b)))
+                .Where(s => demographicTaxonomies == null || demographicTaxonomies.Count == 0
+                                                          || s.ServiceTaxonomies.Any(st => demographicTaxonomies.Contains(st.TaxonomyId)))
+                .Where(s => categoryTaxonomies == null || categoryTaxonomies.Count == 0
+                                                          || s.ServiceTaxonomies.Any(st => categoryTaxonomies.Contains(st.TaxonomyId)))
                 .Select(s => s.ToDomain())
                 .ToList();
             return services;

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -46,6 +46,8 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 var keywords = searchInputText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                 keywords.Append(searchInputText);           // the concatinated value might be in the synonyms database
 
+                keywords = keywords.Where(k => k.Length > 3).ToArray();
+
                 foreach (var keyword in keywords)
                     synonyms.Add(keyword);
 

--- a/LBHFSSPublicAPI/V1/Helpers/AnonEqualityComparer.cs
+++ b/LBHFSSPublicAPI/V1/Helpers/AnonEqualityComparer.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace LBHFSSPublicAPI.V1.Helpers
+{
+    public class AnonEqualityComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T, T, bool> _equalityComparer;
+        private readonly Func<T, int> _hashCodeGenerator;
+
+        public AnonEqualityComparer(Func<T, T, bool> eqComparator, Func<T, int> hashGen)
+        {
+            _equalityComparer = eqComparator;
+            _hashCodeGenerator = hashGen;
+        }
+
+        public bool Equals([AllowNull] T x, [AllowNull] T y)
+        {
+            if (x == null && y == null)
+                return true;
+            else if (x == null || y == null)
+                return false;
+            else
+                return _equalityComparer(x, y);
+        }
+
+        public int GetHashCode([DisallowNull] T obj)
+        {
+            return _hashCodeGenerator(obj).GetHashCode();
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -69,7 +69,7 @@ namespace LBHFSSPublicAPI.V1.UseCase
         {
             requestParams.Search = UrlHelper.DecodeParams(requestParams.Search);
             var gatewayResponse = _servicesGateway.SearchServices(requestParams);
-            var usecaseResponse = gatewayResponse.ToResponse();
+            var usecaseResponse = gatewayResponse.FullMatchServices.ToResponse(); //TODO: need to change factory and implementation
             usecaseResponse.Metadata.PostCode = string.IsNullOrEmpty(requestParams.PostCode) ? null : requestParams.PostCode;
 
             if (!string.IsNullOrEmpty(requestParams.PostCode))

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Geolocation;
 using LBHFSSPublicAPI.V1.Boundary.Request;
 using LBHFSSPublicAPI.V1.Boundary.Response;
+using Response = LBHFSSPublicAPI.V1.Boundary.Response;
 using LBHFSSPublicAPI.V1.Factories;
 using LBHFSSPublicAPI.V1.Gateways.Interfaces;
 using LBHFSSPublicAPI.V1.Helpers;
@@ -68,50 +69,72 @@ namespace LBHFSSPublicAPI.V1.UseCase
         public GetServiceResponseList ExecuteGet(SearchServicesRequest requestParams)
         {
             requestParams.Search = UrlHelper.DecodeParams(requestParams.Search);
-            var gatewayResponse = _servicesGateway.SearchServices(requestParams);
-            var usecaseResponse = gatewayResponse.FullMatchServices.ToResponse(); //TODO: need to change factory and implementation
-            usecaseResponse.Metadata.PostCode = string.IsNullOrEmpty(requestParams.PostCode) ? null : requestParams.PostCode;
+            var postcodeIsGiven = !string.IsNullOrEmpty(requestParams.PostCode);
 
-            if (!string.IsNullOrEmpty(requestParams.PostCode))
+            var gatewayResponse = _servicesGateway.SearchServices(requestParams);
+            var fullMServices = gatewayResponse.FullMatchServices.ToResponseServices();
+            var splitMServices = gatewayResponse.SplitMatchServices.ToResponseServices();
+
+
+            var metadata = new Metadata();
+            metadata.PostCode = postcodeIsGiven ? requestParams.PostCode : null;
+
+            if (postcodeIsGiven)
                 try
                 {
+                    //Get the postcode's coordinates
                     Coordinate? postcodeCoord = _addressesGateway.GetPostcodeCoordinates(requestParams.PostCode);
 
                     if (postcodeCoord.HasValue)
                     {
-                        usecaseResponse.Metadata.PostCodeLatitude = postcodeCoord.Value.Latitude;
-                        usecaseResponse.Metadata.PostCodeLongitude = postcodeCoord.Value.Longitude;
+                        metadata.PostCodeLatitude = postcodeCoord.Value.Latitude;
+                        metadata.PostCodeLongitude = postcodeCoord.Value.Longitude;
 
-                        foreach (var service in usecaseResponse.Services)
-                            foreach (var location in service.Locations)
-                                if (location.Latitude.HasValue && location.Longitude.HasValue)
-                                    location.Distance =
-                                        GeoCalculator.GetDistance(
-                                            postcodeCoord.Value,
-                                            new Coordinate(location.Latitude.Value, location.Longitude.Value),
-                                            decimalPlaces: 1,
-                                            DistanceUnit.Miles
-                                        ) + " miles";
-
+                        fullMServices.CalculateServiceLocationDistances(postcodeCoord.Value);
+                        splitMServices.CalculateServiceLocationDistances(postcodeCoord.Value);
                     }
                     else
                     {
-                        usecaseResponse.Metadata.Error = "Postcode coordinates not found.";
+                        metadata.Error = "Postcode coordinates not found.";
                     }
                 }
                 catch (Exception ex)
                 {
-                    usecaseResponse.Metadata.Error = ex.Message;
+                    metadata.Error = ex.Message;
                 }
 
-            if (!string.IsNullOrEmpty(requestParams.PostCode))
-                usecaseResponse.Services.Sort();
+            if (postcodeIsGiven) // And metadata error is empty
+            {
+                fullMServices.Sort();       // Sort by minimum service location's distance
+                splitMServices.Sort();      // IComparator<Service> is defined on the object iteself
+            }
             else
-                usecaseResponse.Services.Sort(
-                    (s1, s2) => string.Compare(s1.Name, s2.Name)
-                  );
+            {
+                Comparison<Response.Service> byName = (s1, s2) => string.Compare(s1.Name, s2.Name);
 
+                fullMServices.Sort(byName);
+                splitMServices.Sort(byName);
+            }
+
+            var usecaseResponse = ServiceFactory.SearchServiceUsecaseResponse(fullMServices, splitMServices, metadata);
             return usecaseResponse;
+        }
+    }
+
+    public static class UtilityHelper
+    {
+        public static void CalculateServiceLocationDistances(this List<Response.Service> serviceCollection, Coordinate originPoint)
+        {
+            foreach (var service in serviceCollection)
+                foreach (var location in service.Locations)
+                    if (location.Latitude.HasValue && location.Longitude.HasValue)
+                        location.Distance =
+                            GeoCalculator.GetDistance(
+                                originPoint,
+                                new Coordinate(location.Latitude.Value, location.Longitude.Value),
+                                decimalPlaces: 1,
+                                DistanceUnit.Miles
+                            ) + " miles";
         }
     }
 }


### PR DESCRIPTION
# What:
- An upgrade of the search logic searching for matches within services' names.
- An upgrade splits user input into words and then searches for service name matches using split words plus their corresponding synonyms.
- Words of less than 3 characters long are not being searched for.
- Some refactoring within use case and the gateway.
- Gateway contract change, hence a lot of changes to already existing tests.

# Why:
- Currently the search result count decreases when user inputs increasing amount of words into the search. To a degree, when this happens, user should instead get more results, or more accurate results. However due to us doing a simple substring search, despite adding more supporting keywords to a search field, the user will end up with less if any results... because it's less likely to find a service that would match a very long user input string.

# Notes:
- Excluding words consisting of less than 3 characters from the search because we're doing a substring search... meaning that if we were to include them, we'd end up finding too many irrelevant results that contain "the", "a", "an", etc. as their substring.