### PR TITLE
Fix service 404

### DIFF
--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
@@ -38,7 +38,7 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
         public async Task Returns404IfNoMatchingService()
         {
             // act
-            var requestUri = new Uri($"api/v1/services/{Randomm.Id(1,10)}", UriKind.Relative);
+            var requestUri = new Uri($"api/v1/services/{Randomm.Id(1, 10)}", UriKind.Relative);
             var response = Client.GetAsync(requestUri).Result;
             var content = response.Content;
             var stringResponse = await content.ReadAsStringAsync().ConfigureAwait(true);

--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
@@ -33,5 +33,18 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
             actualService.Service.Id.Should().Be(expectedService.Id);
             actualService.Service.Status.Should().Be(service.Status);
         }
+
+        [Test]
+        public async Task Returns404IfNoMatchingService()
+        {
+            // act
+            var requestUri = new Uri($"api/v1/services/{Randomm.Id(1,10)}", UriKind.Relative);
+            var response = Client.GetAsync(requestUri).Result;
+            var content = response.Content;
+            var stringResponse = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var actualService = JsonConvert.DeserializeObject<GetServiceResponse>(stringResponse);
+            // assert
+            response.StatusCode.Should().Be(404);
+        }
     }
 }

--- a/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/ServicesUseCase.cs
@@ -29,7 +29,8 @@ namespace LBHFSSPublicAPI.V1.UseCase
             var servicesGatewayResponse = _servicesGateway.GetService(requestParams.Id);
 
             var usecaseResponse = servicesGatewayResponse.ToResponse();
-
+            if (usecaseResponse == null)
+                return null;
             usecaseResponse.Metadata.PostCode = requestParams.PostCode;
 
             if (!string.IsNullOrEmpty(requestParams.PostCode))


### PR DESCRIPTION
Implemented a fix for the error raised when requesting a service that is not on the system.  The response should be 404 but was throwing an error as the use case was attempting to convert a null response from the gateway.  A check for null before conversion resolved this issue.