### PR TITLE
Add addresses token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ commands:
             DATABASE=$(aws ssm get-parameter --name /fss-public-api/<<parameters.stage>>/postgres-database --query Parameter.Value)
             ADDRESSES_URL=$(aws ssm get-parameter --name /fss-public-api/<<parameters.stage>>/addresses-api-base-url --query Parameter.Value)
             ADDRESSES_KEY=$(aws ssm get-parameter --name /fss-public-api/<<parameters.stage>>/addresses-api-key --query Parameter.Value)
+            ADDRESSES_API_TOKEN=$(aws ssm get-parameter --name /fss-common-api/<<parameters.stage>>/addresses-api-token --query Parameter.Value)
             CONN_STR="Host=localhost;Password=${PASSWORD};Port=6000;Username=${USERNAME};Database=${DATABASE}"
             cd ./LBHFSSPublicAPI/
             ADDRESSES_API_BASE_URL=${ADDRESSES_URL} ADDRESSES_API_KEY=${ADDRESSES_KEY} CONNECTION_STRING=${CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
@@ -150,7 +151,7 @@ jobs:
           command: docker-compose build fss-public-api-test
       - run:
           name: Run tests
-          command: docker-compose run -e ADDRESSES_API_BASE_URL -e ADDRESSES_API_KEY --rm fss-public-api-test
+          command: docker-compose run -e ADDRESSES_API_BASE_URL -e ADDRESSES_API_KEY -e ADDRESSES_API_TOKEN --rm fss-public-api-test
   assume-role-development:
     executor: docker-python
     steps:

--- a/LBHFSSPublicAPI/Startup.cs
+++ b/LBHFSSPublicAPI/Startup.cs
@@ -130,7 +130,10 @@ namespace LBHFSSPublicAPI
             var apiKey = Environment.GetEnvironmentVariable("ADDRESSES_API_KEY")
             ?? throw new ArgumentNullException("Addresses API key");
 
-            var connOptions = new AddressesAPIConnectionOptions(apiBaseUrl, apiKey);
+            var apiToken = Environment.GetEnvironmentVariable("ADDRESSES_API_TOKEN")
+                         ?? throw new ArgumentNullException("Addresses API token");
+
+            var connOptions = new AddressesAPIConnectionOptions(apiBaseUrl, apiKey, apiToken);
 
             services.AddScoped<IAddressesAPIContext>(s =>
             {

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIConnectionOptions.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIConnectionOptions.cs
@@ -4,11 +4,13 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
     {
         public string ApiBaseUrl { get; set; }
         public string ApiKey { get; set; }
+        public string ApiToken { get; set; }
 
-        public AddressesAPIConnectionOptions(string apiBaseUrl, string apiKey)
+        public AddressesAPIConnectionOptions(string apiBaseUrl, string apiKey, string apiToken)
         {
             ApiBaseUrl = apiBaseUrl;
             ApiKey = apiKey;
+            ApiToken = apiToken;
         }
     }
 }

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure
 {
@@ -7,12 +8,14 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
     {
         private readonly string _apiBaseUrl;
         private readonly string _apiKey;
+        private readonly string _apiToken;
         private readonly HttpClient _httpClient = new HttpClient();
 
         public AddressesAPIContext(AddressesAPIConnectionOptions options)
         {
             _apiBaseUrl = options.ApiBaseUrl;
             _apiKey = options.ApiKey;
+            _apiToken = options.ApiToken;
         }
 
         public AddressesAPIContextResponse GetAddressesRequest(string postcode) // asc Block for now.
@@ -23,6 +26,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
             var fullUrlString = $"{_apiBaseUrl}/addresses?PostCode={postcode}&Gazetteer=Both&Format=Detailed"; //Gazeteer Both? or Local?
             request.RequestUri = new Uri(fullUrlString);
             request.Headers.Add("x-api-key", _apiKey);
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiToken);
 
             // Make the request
             var response = _httpClient.SendAsync(request).Result;

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -19,6 +19,7 @@ functions:
       CONNECTION_STRING: Host=${ssm:/fss-public-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/fss-public-api/${self:provider.stage}/postgres-port};Database=${ssm:/fss-public-api/${self:provider.stage}/postgres-database};Username=${ssm:/fss-public-api/${self:provider.stage}/postgres-username};Password=${ssm:/fss-public-api/${self:provider.stage}/postgres-password}
       ADDRESSES_API_BASE_URL: ${ssm:/fss-public-api/${self:provider.stage}/addresses-api-base-url}
       ADDRESSES_API_KEY: ${ssm:/fss-public-api/${self:provider.stage}/addresses-api-key}
+      ADDRESS_API_TOKEN: ${ssm:/fss-common-api/${self:provider.stage}/addresses-api-token}
     events:
       - http:
           path: /{proxy+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Test
       - ADDRESSES_API_BASE_URL=Test
       - ADDRESSES_API_KEY=Test
+      - ADDRESSES_API_TOKEN=Test
     links:
       - test-database
   test-database:


### PR DESCRIPTION
# What
- Added an address token environment variable and an http client header to pass the token for address api calls.

# Why
- The addresses API now requires an auth token when called rather than an API key.