### PR TITLE
Extend search behaviour

### DIFF
--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -58,6 +58,7 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
         {
             var organization = Randomm.Build<Organization>()
                 .Without(o => o.Id)
+                .With(o => o.Status, "active")
                 .With(o => o.ReviewerU, CreateUser())
                 .Create();
             return organization;

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -475,6 +475,60 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             fullMatches.Should().NotBeNull();
             fullMatches.Count.Should().Be(0);
         }
+
+        [TestCase(TestName = "Given search parameters when the SearchService method is called it returns records matching service name or description")]
+        public void GivenSearchParametersWhenSearchServicesGatewayMethodIsCalledThenItReturnsResultsMatchingNameAndDescription()
+        {
+            // arrange
+            var services = EntityHelpers.CreateServices(10);
+            var searchTerm = Randomm.Text();
+            services.First().Name += searchTerm;
+            services[1].Description += searchTerm;
+            var expectedData = new List<Service>();
+            expectedData.Add(services.First());
+            expectedData.Add(services[1]);
+            var requestParams = new SearchServicesRequest();
+            requestParams.Search = searchTerm;
+            DatabaseContext.Services.AddRange(services);
+            DatabaseContext.SaveChanges();
+
+            // act
+            var gatewayResult = _classUnderTest.SearchServices(requestParams);
+            var fullMatches = gatewayResult.FullMatchServices;
+
+            // assert
+            gatewayResult.Should().NotBeNull();
+            fullMatches.Should().NotBeNull();
+            fullMatches.Count.Should().Be(2);
+        }
+
+        [TestCase(TestName = "Given search parameters when the SearchService method is called it returns matching records with organisation name ranked higher than service name")]
+        public void GivenSearchParametersWhenSearchServicesGatewayMethodIsCalledThenItReturnsMatchingRecordsWithOrgNameHigherThanServiceName()
+        {
+            // arrange
+            var services = EntityHelpers.CreateServices(10);
+            var searchTerm = Randomm.Text();
+            services.First().Name += searchTerm;
+            services[1].Organization.Name += searchTerm;
+            var expectedData = new List<Service>();
+            expectedData.Add(services.First());
+            expectedData.Add(services[1]);
+            var requestParams = new SearchServicesRequest();
+            requestParams.Search = searchTerm;
+            DatabaseContext.Services.AddRange(services);
+            DatabaseContext.SaveChanges();
+
+            // act
+            var gatewayResult = _classUnderTest.SearchServices(requestParams);
+            var fullMatches = gatewayResult.FullMatchServices;
+
+            // assert
+            gatewayResult.Should().NotBeNull();
+            fullMatches.Should().NotBeNull();
+            fullMatches.Count.Should().Be(2);
+             fullMatches[0].Name.Should().Be(services[1].Name);
+             fullMatches[1].Name.Should().Be(services[0].Name);
+        }
         #endregion
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Gateways/ServicesGatewayTests.cs
@@ -526,8 +526,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Gateways
             gatewayResult.Should().NotBeNull();
             fullMatches.Should().NotBeNull();
             fullMatches.Count.Should().Be(2);
-             fullMatches[0].Name.Should().Be(services[1].Name);
-             fullMatches[1].Name.Should().Be(services[0].Name);
+            fullMatches[0].Name.Should().Be(services[1].Name);
+            fullMatches[1].Name.Should().Be(services[0].Name);
         }
 
         [TestCase(TestName = "Given user search input that include split part's synonym matches, When SearchService gateway method is called, the split part synonym matches are returned in the appropriate rank.")]

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -41,7 +41,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 .Include(s => s.ServiceLocations)
                 .Include(s => s.ServiceTaxonomies)
                 .ThenInclude(st => st.Taxonomy)
-                .Where(s => s.Status == "active")
+                .Where(s => s.Organization.Status.ToLower() == "active")
                 .AsEnumerable();
 
             IEnumerable<Service> fullMatchServicesQuery = baseQuery,

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -106,7 +106,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 fullMatchServicesQuery = fullMatchServicesQuery.Where(s => filters.Any(p => p(s)));
                 fullMatchServices = AddToCollection(fullMatchServices, fullMatchServicesQuery.Select(s => s.ToDomain()).ToList());
 
-                // Filter on service name
+                // Filter on service description
                 containsUserInput = service => service.Description.ToLower().Contains(searchInputText);
                 containsAnySynonym = service => synonyms.Any(sn => service.Description.ToLower().Contains(sn));
                 filters = new List<Predicate<Service>>() { containsUserInput };


### PR DESCRIPTION
# What
- Extended the search behaviour to include word/phrase search and rank against organisation name, service name and service description respectively.

# Why
- In order to expand the search capabilities and return broader results.

# Note
- The search will now be done against words and phrases on the fields specified and will match against the search term supplied as well as any related synonym configured in the system.