### PR TITLE
Add db fields

### DIFF
--- a/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
@@ -151,6 +151,8 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                 entity.Property(e => e.SubmittedAt).HasColumnName("submitted_at");
 
                 entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+                entity.Property(e => e.LastRevalidation).HasColumnName("last_revalidation");
+                entity.Property(e => e.InRevalidationProcess).HasColumnName("in_revalidation_process");
 
                 entity.HasOne(d => d.ReviewerU)
                     .WithMany(p => p.Organizations)

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210114133524_AddOrganisationReverificationFields.Designer.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210114133524_AddOrganisationReverificationFields.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210114133524_AddOrganisationReverificationFields")]
+    partial class AddOrganisationReverificationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210114133524_AddOrganisationReverificationFields.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210114133524_AddOrganisationReverificationFields.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
+{
+    public partial class AddOrganisationReverificationFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "in_revalidation_process",
+                table: "organizations",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_revalidation",
+                table: "organizations",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "in_revalidation_process",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "last_revalidation",
+                table: "organizations");
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/Organization.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Organization.cs
@@ -44,6 +44,8 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
         public string AdultSafeguardingLeadTrainingYear { get; set; }
         public bool? HasEnhancedSupport { get; set; }
         public bool? IsLocalOfferListed { get; set; }
+        public DateTime? LastRevalidation { get; set; }
+        public bool InRevalidationProcess { get; set; }
 
         public virtual User ReviewerU { get; set; }
         public virtual ICollection<Service> Services { get; set; }


### PR DESCRIPTION
#What
- Added new database fields to track reverification dates and if a reverification process is in progress to allow a utility to manage the process of annual reverifications

#Why
- Organisations need to be reverified every year to ensure that their details remain up to date.

#Notes
- The date of the reverification will be every year from the end of the last reverification process.  This date will be separate from the review date which can occur any time during the year.  The reverification will occur even if an organisation reviewed their information very recently.