### PR TITLE
Update service description

### DIFF
--- a/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -43,7 +43,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Factories
                     st.Taxonomy != null &&
                     st.Taxonomy.Id == c.Id &&
                     st.Taxonomy.Name == c.Name &&
-                    st.Taxonomy.Description == c.Description &&
+                    st.Description == c.Description &&
                     st.Taxonomy.Weight == c.Weight
                     ));
 

--- a/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
+++ b/LBHFSSPublicAPI/V1/Factories/ServiceFactory.cs
@@ -98,7 +98,7 @@ namespace LBHFSSPublicAPI.V1.Factories
                         {
                             Id = st.Taxonomy.Id,
                             Name = st.Taxonomy.Name,
-                            Description = st.Taxonomy.Description,
+                            Description = st.Description,
                             Vocabulary = st.Taxonomy.Vocabulary,
                             Weight = st.Taxonomy.Weight
                         })


### PR DESCRIPTION
# What
- Change which description field is returned for service categories.

# Why
- Service categories have distinct descriptions for each service/category relationships.  This needs to be returned instead of the descriptions on the categories table.