### PR TITLE
Create analytics events

### DIFF
--- a/LBHFSSPublicAPI.Tests/DatabaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/DatabaseTests.cs
@@ -19,6 +19,7 @@ namespace LBHFSSPublicAPI.Tests
             builder.UseNpgsql(ConnectionString.TestDatabase());
             DatabaseContext = new DatabaseContext(builder.Options);
             DatabaseContext.Database.EnsureCreated();
+            DbCleardown.ClearAll(DatabaseContext);
             _transaction = DatabaseContext.Database.BeginTransaction();
             CustomizeAssertions.ApproximationDateTime();
         }
@@ -28,6 +29,7 @@ namespace LBHFSSPublicAPI.Tests
         {
             _transaction.Rollback();
             _transaction.Dispose();
+            DbCleardown.ClearAll(DatabaseContext);
         }
     }
 }

--- a/LBHFSSPublicAPI.Tests/IntegrationTests.cs
+++ b/LBHFSSPublicAPI.Tests/IntegrationTests.cs
@@ -40,6 +40,7 @@ namespace LBHFSSPublicAPI.Tests
             Client = _factory.CreateClient();
             DatabaseContext = new DatabaseContext(_builder.Options);
             DatabaseContext.Database.EnsureCreated();
+            DbCleardown.ClearAll(DatabaseContext);
             _transaction = DatabaseContext.Database.BeginTransaction();
         }
 
@@ -56,8 +57,8 @@ namespace LBHFSSPublicAPI.Tests
             {
                 Console.WriteLine(e.Message);
             }
-
             _transaction.Dispose();
         }
+
     }
 }

--- a/LBHFSSPublicAPI.Tests/TestHelpers/DbCleardown.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/DbCleardown.cs
@@ -1,0 +1,16 @@
+using LBHFSSPublicAPI.V1.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBHFSSPublicAPI.Tests.TestHelpers
+{
+    public static class DbCleardown
+    {
+        public static void ClearAll(DatabaseContext context)
+        {
+            context.Database.ExecuteSqlRaw("TRUNCATE TABLE taxonomies CASCADE");
+            context.Database.ExecuteSqlRaw("TRUNCATE TABLE users CASCADE");
+            context.Database.ExecuteSqlRaw("TRUNCATE TABLE files CASCADE");
+            context.Database.ExecuteSqlRaw("TRUNCATE TABLE organizations CASCADE");
+        }
+    }
+}

--- a/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPublicAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -187,15 +187,12 @@ namespace LBHFSSPublicAPI.Tests.TestHelpers
             };
         }
 
-
-        // public static UserRole CreateUserRole()
-        // {
-        //     var userRole = Randomm.Build<UserRole>()
-        //         .Without(ur => ur.Id)
-        //         .With(ur => ur.IdNavigation, CreateUser())
-        //         .With(ur => ur.Role, CreateRole())
-        //         .Create();
-        //     return userRole;
-        // }
+        public static AnalyticsEvent CreateAnalyticsEvent()
+        {
+            return Randomm.Build<AnalyticsEvent>()
+                .Without(s => s.Id)
+                .With(s => s.Service, CreateService())
+                .Create();
+        }
     }
 }

--- a/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
+++ b/LBHFSSPublicAPI.Tests/V1/E2ETests/GetServices.cs
@@ -17,6 +17,7 @@ namespace LBHFSSPublicAPI.Tests.V1.E2ETests
         public async Task ReturnsThatMatchingService()
         {
             // arrange
+            DatabaseContext.Database.RollbackTransaction();
             var service = EntityHelpers.CreateService();
             DatabaseContext.Services.Add(service);
             DatabaseContext.SaveChanges();

--- a/LBHFSSPublicAPI.Tests/V1/Infrastructure/DatabaseContextTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Infrastructure/DatabaseContextTests.cs
@@ -120,5 +120,16 @@ namespace LBHFSSPublicAPI.Tests.V1.Infrastructure
             var result = DatabaseContext.ServiceLocations.ToList().FirstOrDefault();
             result.Should().BeEquivalentTo(serviceLocation);
         }
+
+        [Test]
+        public void CanCreateAnAnalyticsEventEntity()
+        {
+            var analyticsEvent = EntityHelpers.CreateAnalyticsEvent();
+            DatabaseContext.Add(analyticsEvent);
+            DatabaseContext.SaveChanges();
+            var result = DatabaseContext.ServiceAnalytics.ToList().FirstOrDefault();
+            result.Should().BeEquivalentTo(analyticsEvent);
+        }
+
     }
 }

--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -26,11 +26,16 @@ namespace LBHFSSPublicAPI.V1.Gateways
                 .Include(s => s.Image)
                 .Include(s => s.Organization)
                 .Include(s => s.ServiceLocations)
+                .Include(s => s.ServiceAnalytics)
                 .Include(s => s.ServiceTaxonomies)
                 .ThenInclude(st => st.Taxonomy)
-                .FirstOrDefault(x => x.Id == id)
-                .ToDomain();
-            return service;
+                .FirstOrDefault(x => x.Id == id);
+            service?.ServiceAnalytics.Add(new AnalyticsEvent
+            {
+                TimeStamp = DateTime.Now
+            });
+            _context.SaveChanges();
+            return service.ToDomain();
         }
 
         public SearchServiceGatewayResult SearchServices(SearchServicesRequest requestParams)

--- a/LBHFSSPublicAPI/V1/Infrastructure/AnalyticsEvent.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AnalyticsEvent.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure
+{
+    public class AnalyticsEvent
+    {
+        public int Id { get; set; }
+        public int ServiceId { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public Service Service { get; set; }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
@@ -268,7 +268,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                     .HasColumnName("id")
                     .UseIdentityAlwaysColumn(); ;
 
-                entity.Property(e => e.TimeStamp).HasColumnName("description");
+                entity.Property(e => e.TimeStamp).HasColumnName("timestamp");
 
                 entity.Property(e => e.ServiceId).HasColumnName("service_id");
 

--- a/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/DatabaseContext.cs
@@ -18,6 +18,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
         public virtual DbSet<Role> Roles { get; set; }
         public virtual DbSet<ServiceLocation> ServiceLocations { get; set; }
         public virtual DbSet<ServiceTaxonomy> ServiceTaxonomies { get; set; }
+        public virtual DbSet<AnalyticsEvent> ServiceAnalytics { get; set; }
         public virtual DbSet<Service> Services { get; set; }
         public virtual DbSet<Session> Sessions { get; set; }
         public virtual DbSet<SynonymGroup> SynonymGroups { get; set; }
@@ -257,6 +258,25 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
                     .WithMany(p => p.ServiceTaxonomies)
                     .HasForeignKey(d => d.TaxonomyId)
                     .HasConstraintName("service_taxonomies_taxonomy_id_fkey");
+            });
+
+            modelBuilder.Entity<AnalyticsEvent>(entity =>
+            {
+                entity.ToTable("service_analytics");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("id")
+                    .UseIdentityAlwaysColumn(); ;
+
+                entity.Property(e => e.TimeStamp).HasColumnName("description");
+
+                entity.Property(e => e.ServiceId).HasColumnName("service_id");
+
+                entity.HasOne(d => d.Service)
+                    .WithMany(p => p.ServiceAnalytics)
+                    .HasForeignKey(d => d.ServiceId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("service_analytics_service_id_fkey");
             });
 
             modelBuilder.Entity<Service>(entity =>

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.Designer.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20210118213014_AddAnalyticsTable")]
+    partial class AddAnalyticsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
+{
+    public partial class AddAnalyticsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "service_analytics",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
+                    service_id = table.Column<int>(nullable: false),
+                    description = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_service_analytics", x => x.id);
+                    table.ForeignKey(
+                        name: "service_analytics_service_id_fkey",
+                        column: x => x.service_id,
+                        principalTable: "services",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_service_analytics_service_id",
+                table: "service_analytics",
+                column: "service_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "service_analytics");
+        }
+    }
+}

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/20210118213014_AddAnalyticsTable.cs
@@ -15,7 +15,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
                     id = table.Column<int>(nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
                     service_id = table.Column<int>(nullable: false),
-                    description = table.Column<DateTime>(nullable: false)
+                    timestamp = table.Column<DateTime>(nullable: false)
                 },
                 constraints: table =>
                 {

--- a/LBHFSSPublicAPI/V1/Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
@@ -32,7 +32,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure.Migrations
                         .HasColumnType("integer");
 
                     b.Property<DateTime>("TimeStamp")
-                        .HasColumnName("description")
+                        .HasColumnName("timestamp")
                         .HasColumnType("timestamp without time zone");
 
                     b.HasKey("Id");

--- a/LBHFSSPublicAPI/V1/Infrastructure/Service.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/Service.cs
@@ -9,6 +9,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
         {
             ServiceLocations = new HashSet<ServiceLocation>();
             ServiceTaxonomies = new HashSet<ServiceTaxonomy>();
+            ServiceAnalytics = new HashSet<AnalyticsEvent>();
         }
 
         public int Id { get; set; }
@@ -34,5 +35,6 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
         public virtual Organization Organization { get; set; }
         public virtual ICollection<ServiceLocation> ServiceLocations { get; set; }
         public virtual ICollection<ServiceTaxonomy> ServiceTaxonomies { get; set; }
+        public virtual ICollection<AnalyticsEvent> ServiceAnalytics { get; set; }
     }
 }


### PR DESCRIPTION
# What
- Added a migration to create a new table to store service view analytics
- Updated gateway to add an analytics record whenever a service record is retrieved

# Why
- This will enable us to report on how many views a service receives

# Note
- The actual analytics events will be reported from the portal API supplying this information to VCSOs