### PR TITLE
filter out only active services when returning to front page.

### DIFF
--- a/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPublicAPI/V1/Gateways/ServicesGateway.cs
@@ -30,7 +30,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
             .Include(s => s.ServiceAnalytics)
             .Include(s => s.ServiceTaxonomies)
             .ThenInclude(st => st.Taxonomy)
-            .FirstOrDefault(x => x.Id == id);
+            .FirstOrDefault(x => x.Id == id && x.Status.ToLower() == "active");
             service?.ServiceAnalytics.Add(new AnalyticsEvent
             {
                 TimeStamp = DateTime.Now
@@ -48,6 +48,7 @@ namespace LBHFSSPublicAPI.V1.Gateways
             .Include(s => s.ServiceTaxonomies)
             .ThenInclude(st => st.Taxonomy)
             .Where(s => s.Organization.Status.ToLower() == "published")
+            .Where(s => s.Status.ToLower() == "active")
             .AsEnumerable();
 
             IEnumerable<Service> fullMatchServicesQuery = baseQuery,


### PR DESCRIPTION
## What
- Add filter for service listings to exclude those marked as deleted

## Why
- Listings marked as deleted are still appearing in search results.  Applying this filter will ensure that they do not appear in search results

## Link to ticket
- https://app.clickup.com/t/pvgh7n