### PR TITLE
Remove stale CODEOWNERs file as its blocking further work.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty


### PR DESCRIPTION
# What:
 - Removed the stale CODEOWNERs file.

# Why:
 - The specified maintainers have either left the organisation, or no longer belong to the development team.
 - The repository is currently not being maintained, so it doesn't really have any CODEOWNERs yet.
 - We need to unblock this repository for the infrastructure work we're doing.

# Notes:
 - The pipeline is failing due to expired key. We'll fix that after this change gets merged to master. There's nothing in this PR that would require deployment anyway.