### PR TITLE
Add Terraform support to the pipeline's configuration declarations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,25 @@ commands:
             CONN_STR="Host=localhost;Password=${PASSWORD};Port=6000;Username=${USERNAME};Database=${DATABASE}"
             cd ./LBHFSSPublicAPI/
             ADDRESSES_API_BASE_URL=${ADDRESSES_URL} ADDRESSES_API_KEY=${ADDRESSES_KEY} ADDRESSES_API_TOKEN=${ADDRESSES_API_TOKEN} CONNECTION_STRING=${CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
+  deploy-terraform:
+    description: "Initializes and applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform apply -auto-approve
 
 jobs:
   check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,21 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  preview-terraform:
+    description: "Previews terraform configuration changes"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: preview terraform
 
 jobs:
   check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,21 @@ jobs:
     steps:
       - migrate-database:
           stage: "production"
+  deploy-development-terraform:
+    executor: docker-terraform
+    steps:
+      - deploy-terraform:
+          environment: "development"
+  deploy-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - deploy-terraform:
+          environment: "staging"
+  deploy-production-terraform:
+    executor: docker-terraform
+    steps:
+      - deploy-terraform:
+          environment: "production"
 
 workflows:
   check-and-deploy-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,21 @@ jobs:
     steps:
       - deploy-terraform:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "production"
 
 workflows:
   check-and-deploy-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: circleci/python:3.7
   docker-terraform:
     docker:
-      - image: "hashicorp/terraform:light"
+      - image: hashicorp/terraform:latest
   docker-dotnet:
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:3.1


### PR DESCRIPTION
# What:
 - Updated the terraform docker executor from a deprecated tag to the latest one _(current version switch 1.4.2 -> 1.9.6)_
 - Added terraform resource deployment CCI command.
 - Added terraform resource deployment CCI jobs for each environment.
 - Added terraform preview CCI command.
 - Added terraform preview CCI jobs for each environment.

# Why:
 - We're looking to manage terraform resources via the pipeline rather than relying on terraform runs on local machine.
 - We want to have a terraform preview so that we could preview the changes w/o the need to merge the pull request.

# Notes:
 - Again, the pipeline may be failing after the merge because of the outdated dotnet framework, and some other pipeline dependencies. The pipeline dependencies will upgraded in the coming PRs.

