### PR TITLE
Add manual permit steps before deployment and database migration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,10 +319,17 @@ workflows:
           filters:
             branches:
               only: develop
+      - permit-development-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: develop
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
-            - build-and-test
+            - permit-development-release
           filters:
             branches:
               only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,10 +352,17 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-staging-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-            - build-and-test
+            - permit-staging-release
           filters:
             branches:
               only: master


### PR DESCRIPTION
# What:
 - Add a manual permit requirement before the `development` release & `development` database migration.
 - Add a manual permit requirement before the `staging` release & `staging` database migration.

# Why:
 - No need to artificially limit merges if the changes aren't ready for release.
 - Currently `staging` deployment and `staging` database migration steps are broken due to out of date dependencies and frameworks.

# Notes:
 - The failing deployment and migration steps will need to be fixed as part of a different epic for upgrading the applications across the organisation. For now there's little point to fixing these portions of pipeline as there's nothing to release.
 - The current `feature` pipeline is failing because of a severe terraform drift that should hopefully be addressed shortly as part of a current work on this repository. 