### PR TITLE
Resolve `development` terraform drift for `DevelopmentAPIs` account.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,11 @@ commands:
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
-            if [ "<<parameters.environment>>" = "development" ]
-            then
-              echo "replace provider"
-              terraform state replace-provider registry.terraform.io/-/aws hashicorp/aws
-            fi
+            # if [ "<<parameters.environment>>" = "development" ]
+            # then
+            #   echo "replace provider"
+            #   terraform state replace-provider registry.terraform.io/-/aws hashicorp/aws
+            # fi
             terraform plan
           name: preview terraform
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,11 @@ commands:
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
+            if [ "<<parameters.environment>>" = "development" ]
+            then
+              echo "replace provider"
+              terraform state replace-provider registry.terraform.io/-/aws hashicorp/aws
+            fi
             terraform plan
           name: preview terraform
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -22,6 +22,10 @@ terraform {
   }
 }
 
+provider "aws" {
+  region = "eu-west-2"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -73,6 +73,7 @@ module "postgres_db_development" {
   vpc_id = data.aws_vpc.development_vpc.id
   db_engine = "postgres"
   db_engine_version = "16.3"
+  db_parameter_group_name = "postgres-16"
   db_identifier = "fss-public-dev-db"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.fss_public_postgres_database.value

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -35,11 +35,17 @@ data "aws_vpc" "development_vpc" {
     Name = "apis-dev"
   }
 }
-data "aws_subnet_ids" "development_private_subnets" {
+data "aws_subnets" "development_private_subnets" {
   vpc_id = data.aws_vpc.development_vpc.id
+  
   filter {
     name   = "tag:environment"
     values = ["development"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["*-private-*"]
   }
 }
 
@@ -71,7 +77,7 @@ module "postgres_db_development" {
   db_port  = data.aws_ssm_parameter.fss_public_postgres_port.value
   db_username = data.aws_ssm_parameter.fss_public_postgres_username.value
   db_password = data.aws_ssm_parameter.fss_public_postgres_db_password.value
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
+  subnet_ids = data.aws_subnets.development_private_subnets.ids
   db_allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"
   storage_encrypted = false

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -36,8 +36,11 @@ data "aws_vpc" "development_vpc" {
   }
 }
 data "aws_subnets" "development_private_subnets" {
-  vpc_id = data.aws_vpc.development_vpc.id
-  
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.development_vpc.id]
+  }
+
   filter {
     name   = "tag:environment"
     values = ["development"]

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.69"
+      version = "~> 3.0, < 4.0.0"
     }
   }
   backend "s3" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0, < 4.0.0"
+      version = "~> 3.0"
     }
   }
   backend "s3" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -46,8 +46,8 @@ data "aws_subnets" "development_private_subnets" {
   }
 
   filter {
-    name   = "tag:environment"
-    values = ["development"]
+    name   = "tag:Environment"
+    values = ["Dev"]
   }
 }
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -30,7 +30,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "development_vpc" {
   tags = {
-    Name = "vpc-development-apis-development"
+    Name = "apis-dev"
     }
 }
 data "aws_subnet_ids" "development_private_subnets" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -49,11 +49,6 @@ data "aws_subnets" "development_private_subnets" {
     name   = "tag:environment"
     values = ["development"]
   }
-
-  filter {
-    name   = "name"
-    values = ["*-private-*"]
-  }
 }
 
 data "aws_ssm_parameter" "fss_public_postgres_db_password" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -72,7 +72,7 @@ module "postgres_db_development" {
   environment_name = "development"
   vpc_id = data.aws_vpc.development_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.8"
+  db_engine_version = "16.3"
   db_identifier = "fss-public-dev-db"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.fss_public_postgres_database.value

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -7,24 +7,26 @@
 # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
 # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
-provider "aws" {
-  region  = "eu-west-2"
-  version = "~> 2.0"
-}
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-  application_name = "fss public api"
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.69"
+    }
+  }
   backend "s3" {
     bucket  = "terraform-state-development-apis"
     encrypt = true
     region  = "eu-west-2"
     key     = "services/fss-public-api/state"
   }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+locals {
+  application_name = "fss public api"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 /*    POSTGRES SET UP    */

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -15,7 +15,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
   application_name = "fss public api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -31,31 +31,31 @@ terraform {
 data "aws_vpc" "development_vpc" {
   tags = {
     Name = "apis-dev"
-    }
+  }
 }
 data "aws_subnet_ids" "development_private_subnets" {
   vpc_id = data.aws_vpc.development_vpc.id
   filter {
     name   = "tag:environment"
     values = ["development"]
-    }
+  }
 }
 
- data "aws_ssm_parameter" "fss_public_postgres_db_password" {
-   name = "/fss-public-api/development/postgres-password"
- }
+data "aws_ssm_parameter" "fss_public_postgres_db_password" {
+  name = "/fss-public-api/development/postgres-password"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_username" {
-   name = "/fss-public-api/development/postgres-username"
- }
+data "aws_ssm_parameter" "fss_public_postgres_username" {
+  name = "/fss-public-api/development/postgres-username"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_port" {
-   name = "/fss-public-api/development/postgres-port"
- }
+data "aws_ssm_parameter" "fss_public_postgres_port" {
+  name = "/fss-public-api/development/postgres-port"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_database" {
-   name = "/fss-public-api/development/postgres-database"
- }
+data "aws_ssm_parameter" "fss_public_postgres_database" {
+  name = "/fss-public-api/development/postgres-database"
+}
 
 module "postgres_db_development" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -15,7 +15,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
   application_name = "fss public api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -31,31 +31,32 @@ terraform {
 data "aws_vpc" "production_vpc" {
   tags = {
     Name = "vpc-production-apis-production"
-    }
+  }
 }
 data "aws_subnet_ids" "production_private_subnets" {
   vpc_id = data.aws_vpc.production_vpc.id
   filter {
     name   = "tag:Type"
     values = ["private"]
-    }
+  }
 }
 
- data "aws_ssm_parameter" "fss_public_postgres_db_password" {
-   name = "/fss-public-api/production/postgres-password"
- }
+data "aws_ssm_parameter" "fss_public_postgres_db_password" {
+  name = "/fss-public-api/production/postgres-password"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_username" {
-   name = "/fss-public-api/production/postgres-username"
- }
+data "aws_ssm_parameter" "fss_public_postgres_username" {
+  name = "/fss-public-api/production/postgres-username"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_port" {
-   name = "/fss-public-api/production/postgres-port"
- }
+data "aws_ssm_parameter" "fss_public_postgres_port" {
+  name = "/fss-public-api/production/postgres-port"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_database" {
-   name = "/fss-public-api/production/postgres-database"
- }
+data "aws_ssm_parameter" "fss_public_postgres_database" {
+  name = "/fss-public-api/production/postgres-database"
+}
+
 module "postgres_db_production" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
   environment_name = "production"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -15,7 +15,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
   application_name = "fss public api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -31,31 +31,31 @@ terraform {
 data "aws_vpc" "staging_vpc" {
   tags = {
     Name = "vpc-staging-apis-staging"
-    }
+  }
 }
 data "aws_subnet_ids" "staging_private_subnets" {
   vpc_id = data.aws_vpc.staging_vpc.id
   filter {
     name   = "tag:Type"
     values = ["private"]
-    }
+  }
 }
 
- data "aws_ssm_parameter" "fss_public_postgres_db_password" {
-   name = "/fss-public-api/staging/postgres-password"
- }
+data "aws_ssm_parameter" "fss_public_postgres_db_password" {
+  name = "/fss-public-api/staging/postgres-password"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_username" {
-   name = "/fss-public-api/staging/postgres-username"
- }
+data "aws_ssm_parameter" "fss_public_postgres_username" {
+  name = "/fss-public-api/staging/postgres-username"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_port" {
-   name = "/fss-public-api/staging/postgres-port"
- }
+data "aws_ssm_parameter" "fss_public_postgres_port" {
+  name = "/fss-public-api/staging/postgres-port"
+}
 
- data "aws_ssm_parameter" "fss_public_postgres_database" {
-   name = "/fss-public-api/staging/postgres-database"
- }
+data "aws_ssm_parameter" "fss_public_postgres_database" {
+  name = "/fss-public-api/staging/postgres-database"
+}
 
 module "postgres_db_staging" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"


### PR DESCRIPTION
# What:
 - Fix the terraform file to the point where it is able to display the `terraform plan` output.
 - Resolve the terraform drift for the `development environment on `DevelopmentAPIs` account.

# Why:
 - Tech debt.

# Notes:
 - The pipeline is shown as failing because the `staging` and `production` previews fail terraform plan due to drift in VPC names on `StagingAPIs` and `ProductionsAPIs` accounts.