### PR TITLE
Fix `staging` terraform drift of forced database replacement due to `encryption` within the `StagingAPIs` account.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,8 @@ commands:
             if [ <<parameters.environment>> = "staging" ]
             then
               aws rds delete-db-instance \
-                --db-instance-identifier 'fss-public-staging-db-staging-encrypted'
-                --skip-final-snapshot
+                --db-instance-identifier 'fss-public-staging-db-staging-encrypted' \
+                --skip-final-snapshot \
                 --delete-automated-backups
             fi
           name: Remove the duplicate 1st of the 1 encrypted FSS databases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,24 +149,6 @@ commands:
             # fi
             terraform plan
           name: preview terraform
-  remove-duplicate-encrypted-db:
-    description: "Removes the encrypted db with the wrong name. Keeps only the one with the correct name."
-    parameters:
-      environment:
-        type: string
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - run:
-          command: |
-            if [ <<parameters.environment>> = "staging" ]
-            then
-              aws rds delete-db-instance \
-                --db-instance-identifier 'fss-public-staging-db-staging-encrypted' \
-                --skip-final-snapshot \
-                --delete-automated-backups
-            fi
-          name: Remove the duplicate 1st of the 1 encrypted FSS databases
 
 jobs:
   check-code-formatting:
@@ -265,11 +247,6 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
-  remove-duplicate-unused-db:
-    executor: aws-cli/default
-    steps:
-      - remove-duplicate-encrypted-db:
-          environment: "staging"
 
 workflows:
   feature:
@@ -311,15 +288,6 @@ workflows:
               ignore:
                 - develop
                 - master
-      - remove-duplicate-unused-db:
-          requires:
-            - assume-role-staging
-          filters:
-            # Trigger duplicate database's deletion on this feature branch to reduce the PR count.
-            # This is a one-off operation, so this could will be removed before the PR merge to develop branch.
-            branches:
-              only:
-                - fix-staging-drift
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
-  decouple-from-old-module:
+  remove-duplicate-unused-db:
     executor: docker-terraform
     steps:
       - remove-duplicate-encrypted-db:
@@ -311,14 +311,11 @@ workflows:
               ignore:
                 - develop
                 - master
-      - decouple-from-old-module:
+      - remove-duplicate-unused-db:
           requires:
             - assume-role-staging
           filters:
             branches:
-              # had to run this on feature because when the target
-              # module gets removed, this command won't be able to
-              # target it.
               only:
                 - already-ran-no-need-to-trigger
       - preview-staging-terraform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,8 +149,8 @@ commands:
             # fi
             terraform plan
           name: preview terraform
-  decouple-from-module:
-    description: "Decouple the old module pointers to the security and subnet groups used by FSS."
+  remove-duplicate-encrypted-db:
+    description: "Removes the encrypted db with the wrong name. Keeps only the one with the correct name."
     parameters:
       environment:
         type: string
@@ -159,14 +159,14 @@ commands:
       - checkout
       - run:
           command: |
-            cd ./terraform/<<parameters.environment>>/
-            terraform get -update=true
-            terraform init
-            terraform state rm \
-              'module.postgres_db_staging.aws_db_subnet_group.db_subnets' \
-              'module.postgres_db_staging.module.db_security_group.aws_security_group.lbh_db_traffic'
-            terraform plan
-          name: Decouple security and subnet group resource from the old module
+            if [ <<parameters.environment>> = "staging" ]
+            then
+              delete-db-instance \
+                --db-instance-identifier 'fss-public-staging-db-staging-encrypted'
+                --skip-final-snapshot
+                --delete-automated-backups
+            fi
+          name: Remove the duplicate 1st of the 1 encrypted FSS databases
 
 jobs:
   check-code-formatting:
@@ -268,7 +268,7 @@ jobs:
   decouple-from-old-module:
     executor: docker-terraform
     steps:
-      - decouple-from-module:
+      - remove-duplicate-encrypted-db:
           environment: "staging"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,6 @@ commands:
               --storage-type "gp2" \
               --no-multi-az \
               --region "eu-west-2" \
-              --db-name "fsspublicstaging" \
               --vpc-security-group-ids "$SECURITY_GROUP_ID"
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,14 +296,6 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
-  reviewable-cli-job:
-    executor: aws-cli/default
-    steps:
-      - reviewable-console-changes
-  reviewable-snapshot:
-    executor: aws-cli/default
-    steps:
-      - reviewable-snapshot-restore
 
 workflows:
   feature:
@@ -345,20 +337,6 @@ workflows:
               ignore:
                 - develop
                 - master
-      - reviewable-snapshot:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only:
-                - fix-staging-drift
-      - reviewable-cli-job:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only:
-                - create-encrypted-staging-snapshot
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,9 +315,11 @@ workflows:
           requires:
             - assume-role-staging
           filters:
+            # Trigger duplicate database's deletion on this feature branch to reduce the PR count.
+            # This is a one-off operation, so this could will be removed before the PR merge to develop branch.
             branches:
               only:
-                - already-ran-no-need-to-trigger
+                - fix-staging-drift
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ commands:
           command: |
             if [ <<parameters.environment>> = "staging" ]
             then
-              delete-db-instance \
+              aws rds delete-db-instance \
                 --db-instance-identifier 'fss-public-staging-db-staging-encrypted'
                 --skip-final-snapshot
                 --delete-automated-backups

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ commands:
         type: string
     steps:
       - *attach_workspace
-      - checkout
+      - aws-cli/install
       - run:
           command: |
             if [ <<parameters.environment>> = "staging" ]
@@ -266,7 +266,7 @@ jobs:
       - preview-terraform:
           environment: "production"
   remove-duplicate-unused-db:
-    executor: docker-terraform
+    executor: aws-cli/default
     steps:
       - remove-duplicate-encrypted-db:
           environment: "staging"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,55 +149,6 @@ commands:
             # fi
             terraform plan
           name: preview terraform
-  reviewable-console-changes:
-    description: "Copy an existing db snapshot & add encryption to it."
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - run:
-          name: copy a database snapshot w encryption
-          command: |
-            default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]" | sed 's/"//g')
-
-            snapshot_to_copy_arn=$(aws rds describe-db-snapshots --query "DBSnapshots[?DBSnapshotIdentifier == 'fss-public-staging-db-staging-manual-snapshot'].DBSnapshotArn | [0]" | sed 's/"//g')
-
-            aws rds copy-db-snapshot \
-              --source-db-snapshot-identifier $snapshot_to_copy_arn \
-              --target-db-snapshot-identifier 'fss-public-staging-db-staging-manual-snapshot-w-encryption' \
-              --source-region 'eu-west-2' \
-              --copy-tags \
-              --no-copy-option-group \
-              --kms-key-id $default_kms_id
-  reviewable-snapshot-restore:
-    description: "Restore an FSS database from snapshot with encryption."
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - run:
-          name: restore database from snapshot
-          command: |
-            SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --query "SecurityGroups[?contains(GroupName,'allow_fsspublicstaging_db')].GroupId | [0]" | sed -e 's/"//g')
-
-            aws rds restore-db-instance-from-db-snapshot \
-              --db-instance-identifier "fss-public-staging-db-staging-encrypted" \
-              --db-instance-class "db.t3.micro" \
-              --db-snapshot-identifier fss-public-staging-db-staging-manual-snapshot-w-encryption \
-              --db-subnet-group-name "fsspublicstaging-db-subnet-staging" \
-              --auto-minor-version-upgrade \
-              --ca-certificate-identifier "rds-ca-rsa2048-g1" \
-              --copy-tags-to-snapshot \
-              --db-parameter-group-name "postgres-16" \
-              --option-group-name "default:postgres-16" \
-              --deletion-protection \
-              --no-enable-iam-database-authentication \
-              --engine "postgres" \
-              --engine-lifecycle-support "open-source-rds-extended-support-disabled" \
-              --port 5432 \
-              --no-publicly-accessible \
-              --storage-type "gp2" \
-              --no-multi-az \
-              --region "eu-west-2" \
-              --vpc-security-group-ids "$SECURITY_GROUP_ID"
 
 jobs:
   check-code-formatting:

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -92,4 +92,7 @@ module "postgres_db_staging_encrypted" {
   publicly_accessible     = false
   storage_encrypted       = true
   project_name            = "fss public api"
+
+  # Delete related.
+  deletion_protection     = true
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -93,6 +93,7 @@ module "postgres_db_staging_encrypted" {
   storage_encrypted       = true
   project_name            = "fss public api"
 
-  # Delete related.
+  # Delete / restore related.
   deletion_protection     = true
+  copy_tags_to_snapshot   = true
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -30,7 +30,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "staging_vpc" {
   tags = {
-    Name = "vpc-staging-apis-staging"
+    Name = "apis-stg"
   }
 }
 data "aws_subnet_ids" "staging_private_subnets" {


### PR DESCRIPTION
# What:
 - Imported the `fss-public-encrypted-db-staging` postgres RDS instance with encryption into the new `postgres_db_staging_encrypted` terraform module.
 - Imported the subnet and security groups from the old `postgres_db_staging` database terraform module onto the new one.
 - Decoupled the subnet and security groups from the old module.
 - Deleted the old database module, in so triggering the deletion of the non-encrypted `fss-public-staging-db-staging` database.
 - Solve additional drift of a couple other properties.

# Why:
 - All this was done to resolve a severe terraform drift caused by the CE team's changes to the shared postgres database terraform module that force data encryption on the module users. Terraform handles such change by deleting the database instance with data, and spinning up the new database instance w/o data, but with the encryption enabled. As such these round about workarounds of creating snapshots, modifying them, and restoring them, etc. were needed to preserve the data whilst enabling the encryption.

# Notes:
 - The remaining terraform drift shown in the staging preview is likely to be a red herring. We've doubled checked the SSM values that dictate the values of the keys that are supposedly being updated. We have found no difference between those keys now and how they were the last time the application was deployed. The values used by the database module match what the API connection strings contain, so there should be no issues there.
 - Apart the above fake drift, there were a couple of default key values added due to us using a newer terraform provider version. Those values were determined to be of no consequence to the service's operation.
 - The encrypted database copy was created partly via AWS console UI, and partly via AWS CLI, hence the need for import. There was no clean way to do these operations using the Terraform alone.
 - We've done the testing by doing the API calls. The encrypted database connected to the API returns the expected data as well there are no connection issues.
 - We've updated the the Parameter Store postgres database host key with the encrypted database's endpoint URL.
 - We've also updated the public and portal API lambda connection strings to point to the new endpoint URL to prevent the need for the application re-deployment.
 - This PR has a large commit count as a lot of the encrypted database creation work & related cleanup was done via AWS CLI through the pipeline so that we'd have a reference for the future when we come up against this kind of work and issues again. So those changes were added through commits, merged as a PR to have a reference, and then removed within this main feature branch as those changes were one-off commands that were no longer needed.
 - The pipeline production preview steps shows as failing because this branch was created before the production terraform drift was resolved. This failure is already resolved and merged to the master branch.

# Subet PRs:
You can see the more in-depth descriptions, as well as the grouped related changes on the individual PRs that made up this PR.
 - #103 
 - #104 
 - #105 
 - #106 