### PR TITLE
Fix `production` terraform drift for `ProductionAPIs` account.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -62,7 +62,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id = data.aws_vpc.production_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.9"
+  db_engine_version = "16.3"
   db_identifier = "fss-public-production"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.fss_public_postgres_database.value

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,7 +30,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "production_vpc" {
   tags = {
-    Name = "vpc-production-apis-production"
+    Name = "apis-prod"
   }
 }
 data "aws_subnet_ids" "production_private_subnets" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -7,24 +7,30 @@
 # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
 # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
-provider "aws" {
-  region  = "eu-west-2"
-  version = "~> 2.0"
-}
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-  application_name = "fss public api"
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
   backend "s3" {
     bucket  = "terraform-state-production-apis"
     encrypt = true
     region  = "eu-west-2"
     key     = "services/fss-public-api/state"
   }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+locals {
+  application_name = "fss public api"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 /*    POSTGRES SET UP    */

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -63,6 +63,7 @@ module "postgres_db_production" {
   vpc_id = data.aws_vpc.production_vpc.id
   db_engine = "postgres"
   db_engine_version = "16.3"
+  db_parameter_group_name = "postgres-16"
   db_identifier = "fss-public-production"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.fss_public_postgres_database.value

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -84,4 +84,7 @@ module "postgres_db_production" {
   multi_az = true //only true if production deployment
   publicly_accessible = false
   project_name = "fss public api"
+  additional_tags = {
+    BackupPolicy = "Prod"
+  }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -70,6 +70,7 @@ module "postgres_db_production" {
   db_engine = "postgres"
   db_engine_version = "16.3"
   db_parameter_group_name = "postgres-16"
+  db_allow_major_version_upgrade = true
   db_identifier = "fss-public-production"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.fss_public_postgres_database.value


### PR DESCRIPTION
# What:
 - Use more recent terraform AWS provider version.
 - Update the `production` VPC to match the new `ProductionAPIs` VPC name.
 - Sync the `ProductionAPIs` AWS RDS instance parameters with the terraform file.

# Why:
 - Solving technical debt.

# Notes:
 - The pipeline is shown as failing due to failing `staging` preview. Staging terraform drift is a more complex case that cannot be solved via terraform and it requires manual console work. It will be dealt with in another PR.