### PR TITLE
Create a copy of FSS snapshot that's ready for restoring the database with encryption (via AWS CLI).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@5.1.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,15 @@ commands:
             # fi
             terraform plan
           name: preview terraform
+  reviewable-console-changes:
+    description: "Copy an existing db snapshot & add encryption to it."
+    steps:
+      - *attach_workspace
+      - aws-cli/install
+      - run:
+          name: copy a database snapshot w encryption
+          command: |
+            exit 0
 
 jobs:
   check-code-formatting:
@@ -247,6 +256,10 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
+  reviewable-cli-job:
+    executor: aws-cli/default
+    steps:
+      - reviewable-console-changes
 
 workflows:
   feature:
@@ -288,6 +301,13 @@ workflows:
               ignore:
                 - develop
                 - master
+      - reviewable-cli-job:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only:
+                - create-encrypted-staging-snapshot
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,9 +157,9 @@ commands:
       - run:
           name: copy a database snapshot w encryption
           command: |
-            default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]")
+            default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]" | sed 's/"//g')
 
-            snapshot_to_copy_arn=$(aws rds describe-db-snapshots --query "DBSnapshots[?DBSnapshotIdentifier == 'fss-public-staging-db-staging-manual-snapshot'].DBSnapshotArn | [0]")
+            snapshot_to_copy_arn=$(aws rds describe-db-snapshots --query "DBSnapshots[?DBSnapshotIdentifier == 'fss-public-staging-db-staging-manual-snapshot'].DBSnapshotArn | [0]" | sed 's/"//g')
 
             aws rds copy-db-snapshot \
               --source-db-snapshot-identifier $snapshot_to_copy_arn \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,8 @@ commands:
           name: copy a database snapshot w encryption
           command: |
             default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]")
-            exit 0
+            snapshot_to_copy_arn=$(aws rds describe-db-snapshots --query "DBSnapshots[?DBSnapshotIdentifier == 'fss-public-staging-db-staging-manual-snapshot'].DBSnapshotArn | [0]")
+            echo $snapshot_to_copy_arn
 
 jobs:
   check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,8 +158,16 @@ commands:
           name: copy a database snapshot w encryption
           command: |
             default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]")
+
             snapshot_to_copy_arn=$(aws rds describe-db-snapshots --query "DBSnapshots[?DBSnapshotIdentifier == 'fss-public-staging-db-staging-manual-snapshot'].DBSnapshotArn | [0]")
-            echo $snapshot_to_copy_arn
+
+            aws rds copy-db-snapshot \
+              --source-db-snapshot-identifier $snapshot_to_copy_arn \
+              --target-db-snapshot-identifier 'fss-public-staging-db-staging-manual-snapshot-w-encryption' \
+              --source-region 'eu-west-2' \
+              --copy-tags \
+              --no-copy-option-group \
+              --kms-key-id $default_kms_id
 
 jobs:
   check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ commands:
       - run:
           name: copy a database snapshot w encryption
           command: |
+            default_kms_id=$(aws kms list-aliases --query "Aliases[?contains(AliasName, 'aws/rds')].TargetKeyId | [0]")
             exit 0
 
 jobs:


### PR DESCRIPTION
# What:
 - Changes to trigger the creation of the FSS `StagingAPIs` account database's snapshot with the AWS-managed KMS encryption key.

# Why:
 - To resolve the `staging` environment terraform drift of terraform attempting to replace the database, we need to resolve the encryption issue. We're solving this issue by creating a copy of a snapshot that's ready with encryption & we will be restoring a database from that later on.