### PR TITLE
Rewire FSS `StagingAPIs` terraform modules configuration for the terraform file to point to the encrypted database instead.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -9,7 +9,7 @@
 
 provider "aws" {
   region  = "eu-west-2"
-  version = "~> 2.0"
+  version = "~> 3.0"
 }
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -77,3 +77,24 @@ module "postgres_db_staging" {
   publicly_accessible = false
   project_name = "fss public api"
 }
+
+module "postgres_db_staging_encrypted" {
+  source                  = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+  environment_name        = "staging"
+  vpc_id                  = data.aws_vpc.staging_vpc.id
+  db_engine               = "postgres"
+  db_engine_version       = "16.3"
+  db_parameter_group_name = "postgres-16"
+  db_identifier           = "fss-public-staging-db-staging-encrypted"
+  db_instance_class       = "db.t3.micro"
+  db_name                 = data.aws_ssm_parameter.fss_public_postgres_database.value
+  db_port                 = data.aws_ssm_parameter.fss_public_postgres_port.value
+  db_username             = data.aws_ssm_parameter.fss_public_postgres_username.value
+  db_password             = data.aws_ssm_parameter.fss_public_postgres_db_password.value
+  subnet_ids              = data.aws_subnet_ids.staging_private_subnets.ids
+  db_allocated_storage    = 20
+  maintenance_window      = "sun:10:00-sun:10:30"
+  multi_az                = false
+  publicly_accessible     = false
+  project_name            = "fss public api"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -106,5 +106,6 @@ module "postgres_db_staging_encrypted" {
   maintenance_window      = "sun:10:00-sun:10:30"
   multi_az                = false
   publicly_accessible     = false
+  storage_encrypted       = true
   project_name            = "fss public api"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -79,6 +79,11 @@ module "postgres_db_staging" {
 }
 
 import {
+  to = module.postgres_db_staging_encrypted.aws_db_instance.lbh-db
+  id = "fss-public-staging-db-staging-encrypted"
+}
+
+import {
   to = module.postgres_db_staging_encrypted.module.db_security_group.aws_security_group.lbh_db_traffic
   id = "sg-04c73000bf97eae7e"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -78,6 +78,16 @@ module "postgres_db_staging" {
   project_name = "fss public api"
 }
 
+import {
+  to = module.postgres_db_staging_encrypted.module.db_security_group.aws_security_group.lbh_db_traffic
+  id = "sg-04c73000bf97eae7e"
+}
+
+import {
+  to = module.postgres_db_staging_encrypted.aws_db_subnet_group.db_subnets
+  id = "fsspublicstaging-db-subnet-staging"
+}
+
 module "postgres_db_staging_encrypted" {
   source                  = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
   environment_name        = "staging"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -100,7 +100,7 @@ module "postgres_db_staging_encrypted" {
   db_engine               = "postgres"
   db_engine_version       = "16.3"
   db_parameter_group_name = "postgres-16"
-  db_identifier           = "fss-public-staging-db-staging-encrypted"
+  db_identifier           = "fss-public-encrypted"
   db_instance_class       = "db.t3.micro"
   db_name                 = data.aws_ssm_parameter.fss_public_postgres_database.value
   db_port                 = data.aws_ssm_parameter.fss_public_postgres_port.value

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -80,7 +80,7 @@ module "postgres_db_staging" {
 
 import {
   to = module.postgres_db_staging_encrypted.aws_db_instance.lbh-db
-  id = "fss-public-staging-db-staging-encrypted"
+  id = "fss-public-encrypted-db-staging"
 }
 
 import {


### PR DESCRIPTION
# What:
 - Import the FSS `staging` database that was restored from snapshot with the encryption.
 - Import the database subnet and security groups into the new module from the old module.

# Why:
 - To resolve the terraform drift where the original non-encrypted database was getting attempted to be destroyed and recreated due to hardcoded `storage_encrypted = true` flag within the shared module.

# Note:
 - The import of the security and subnet groups merely makes the new module point to these resources that an old module still points to. The pointers from the old module need to be removed manually via `terraform state rm` command.