### PR TITLE
Delete non-encrypted `staging` database and decouple that module's subnet and security group from this removed module.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,24 @@ commands:
             # fi
             terraform plan
           name: preview terraform
+  decouple-from-module:
+    description: "Decouple the old module pointers to the security and subnet groups used by FSS."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform state rm \
+              'module.postgres_db_staging_encrypted.aws_db_subnet_group.db_subnets' \
+              'module.postgres_db_staging_encrypted.module.db_security_group.aws_security_group.lbh_db_traffic'
+            terraform plan
+          name: Decouple security and subnet group resource from the old module
 
 jobs:
   check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,8 +316,11 @@ workflows:
             - assume-role-staging
           filters:
             branches:
+              # had to run this on feature because when the target
+              # module gets removed, this command won't be able to
+              # target it.
               only:
-                - delete-and-decouple-old-module
+                - already-ran-no-need-to-trigger
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,11 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
+  decouple-from-old-module:
+    executor: docker-terraform
+    steps:
+      - decouple-from-module:
+          environment: "staging"
 
 workflows:
   feature:
@@ -306,6 +311,13 @@ workflows:
               ignore:
                 - develop
                 - master
+      - decouple-from-old-module:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only:
+                - delete-and-decouple-old-module
       - preview-staging-terraform:
           requires:
             - assume-role-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,8 @@ commands:
             terraform get -update=true
             terraform init
             terraform state rm \
-              'module.postgres_db_staging_encrypted.aws_db_subnet_group.db_subnets' \
-              'module.postgres_db_staging_encrypted.module.db_security_group.aws_security_group.lbh_db_traffic'
+              'module.postgres_db_staging.aws_db_subnet_group.db_subnets' \
+              'module.postgres_db_staging.module.db_security_group.aws_security_group.lbh_db_traffic'
             terraform plan
           name: Decouple security and subnet group resource from the old module
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -57,27 +57,6 @@ data "aws_ssm_parameter" "fss_public_postgres_database" {
   name = "/fss-public-api/staging/postgres-database"
 }
 
-module "postgres_db_staging" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "staging"
-  vpc_id = data.aws_vpc.staging_vpc.id
-  db_engine = "postgres"
-  db_engine_version = "11.8"
-  db_identifier = "fss-public-staging"
-  db_instance_class = "db.t2.micro"
-  db_name = data.aws_ssm_parameter.fss_public_postgres_database.value
-  db_port  = data.aws_ssm_parameter.fss_public_postgres_port.value
-  db_username = data.aws_ssm_parameter.fss_public_postgres_username.value
-  db_password = data.aws_ssm_parameter.fss_public_postgres_db_password.value
-  subnet_ids = data.aws_subnet_ids.staging_private_subnets.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "fss public api"
-}
-
 import {
   to = module.postgres_db_staging_encrypted.aws_db_instance.lbh-db
   id = "fss-public-encrypted-db-staging"


### PR DESCRIPTION
# What:
 - Decoupled the FSS `StagingAPIs` subnet and security groups from the old database module _(no encryption)_.
 - Removed the FSS `StagingaAPIs` non-encrypted database `fss-public-staging-db-staging`.

# Why:
 - The mentioned subnet and security groups have been imported to a new database module _(with encryption)_. PR #105 
 - The encrypted database was imported as part of the above linked PR & is a replacement to the non-encrypted one.

# Notes:
 - The production terraform preview is failing because this branch is out of date with `master`.