### PR TITLE
.Net 8 upgrade

### DIFF
--- a/LBHFSSPublicAPI.Tests/DatabaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/DatabaseTests.cs
@@ -1,3 +1,4 @@
+using System;
 using LBHFSSPublicAPI.Tests.TestHelpers;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,8 @@ namespace LBHFSSPublicAPI.Tests
         [SetUp]
         public void RunBeforeAnyTests()
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
             var builder = new DbContextOptionsBuilder();
             builder.UseNpgsql(ConnectionString.TestDatabase());
             DatabaseContext = new DatabaseContext(builder.Options);

--- a/LBHFSSPublicAPI.Tests/Dockerfile
+++ b/LBHFSSPublicAPI.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/LBHFSSPublicAPI.Tests/IntegrationTests.cs
+++ b/LBHFSSPublicAPI.Tests/IntegrationTests.cs
@@ -22,6 +22,8 @@ namespace LBHFSSPublicAPI.Tests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
             _connection = new NpgsqlConnection(ConnectionString.TestDatabase());
             _connection.Open();
             var npgsqlCommand = _connection.CreateCommand();

--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -12,7 +12,10 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.11.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -13,14 +13,14 @@
         <PackageReference Include="AutoFixture" Version="4.11.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
         <PackageReference Include="Bogus" Version="25.0.4" />
         <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="nunit" Version="3.11.0" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
         <PackageReference Include="Geolocation" Version="1.2.1" />
     </ItemGroup>
 

--- a/LBHFSSPublicAPI.Tests/MockWebApplicationFactory.cs
+++ b/LBHFSSPublicAPI.Tests/MockWebApplicationFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data.Common;
 using LBHFSSPublicAPI;
 using LBHFSSPublicAPI.V1.Infrastructure;
@@ -25,6 +26,8 @@ namespace LBHFSSPublicAPI.Tests
                 .UseStartup<Startup>();
             builder.ConfigureServices(services =>
             {
+                AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
                 var dbBuilder = new DbContextOptionsBuilder();
                 dbBuilder.UseNpgsql(_connection);
                 var context = new DatabaseContext(dbBuilder.Options);

--- a/LBHFSSPublicAPI/Dockerfile
+++ b/LBHFSSPublicAPI/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /app
 

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -33,7 +33,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.0.7" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Geolocation" Version="1.2.1" />
   </ItemGroup>
 

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Geolocation" Version="1.2.1" />
   </ItemGroup>

--- a/LBHFSSPublicAPI/Startup.cs
+++ b/LBHFSSPublicAPI/Startup.cs
@@ -118,6 +118,7 @@ new List<string>()
         private static void ConfigureDbContext(IServiceCollection services)
         {
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? "Host=127.0.0.1;Database=testdb;port=6543;username=postgres;password=mypassword;";
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             services.AddDbContext<DatabaseContext>(
             opt => opt.UseNpgsql(connectionString));
         }

--- a/LBHFSSPublicAPI/build.cmd
+++ b/LBHFSSPublicAPI/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/fss-public-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/fss-public-api.zip

--- a/LBHFSSPublicAPI/build.sh
+++ b/LBHFSSPublicAPI/build.sh
@@ -8,7 +8,7 @@ then
 fi
 
 #dotnet restore
-dotnet tool install --global Amazon.Lambda.Tools --version 4.0.0
+dotnet tool install --global Amazon.Lambda.Tools
 
 
 # (for CI) ensure that the newly-installed tools are on PATH
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/fss-public-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/fss-public-api.zip

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -1,14 +1,14 @@
 service: fss-public-api
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet8
   timeout: 15
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/fss-public-api.zip
+  artifact: ./bin/release/net8.0/fss-public-api.zip
 
 functions:
   fssPublicApi:

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: setup
 setup:
-	docker-compose build
+	docker compose build
 
 .PHONY: build
 build:
-	docker-compose build fss-public-api
+	docker compose build fss-public-api
 
 .PHONY: serve
 serve:
-	docker-compose build fss-public-api && docker-compose up fss-public-api
+	docker compose build fss-public-api && docker compose up fss-public-api
 
 .PHONY: shell
 shell:
-	docker-compose run fss-public-api bash
+	docker compose run fss-public-api bash
 
 .PHONY: test
 test:
-	docker-compose up test-database & docker-compose build fss-public-api-test && docker-compose up fss-public-api-test
+	docker compose up test-database & docker compose build fss-public-api-test && docker compose up fss-public-api-test
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
# What
This PR updates the dotnet version for the API and test solution to version 8. A number of packages have also been updated to later versions to comply with this change.
# Why
The dotnet version this project is currently on is unsupported by AWS and as such needs to be updated to a more recent version.