### PR TITLE
Update Serverless to V4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@5.1.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:
@@ -47,11 +46,8 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
+
       - run:
           name: Install serverless CLI
           command: npm i -g serverless
@@ -65,7 +61,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./LBHFSSPublicAPI/
-            sls deploy --stage <<parameters.stage>> --conceal
+            npx --yes serverless@4 deploy --stage <<parameters.stage>> --conceal
   migrate-database:
     description: "Migrate database"
     parameters:
@@ -345,6 +341,8 @@ workflows:
             branches:
               only: develop
       - deploy-to-development:
+          context:
+            - "Serverless Framework"
           requires:
             - assume-role-development
           filters:
@@ -378,6 +376,8 @@ workflows:
             branches:
               only: master
       - deploy-to-staging:
+          context:
+            - "Serverless Framework"
           requires:
             - assume-role-staging
           filters:
@@ -398,6 +398,8 @@ workflows:
             branches:
               only: master
       - deploy-to-production:
+          context:
+            - "Serverless Framework"
           requires:
             - assume-role-production
           filters:

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -29,9 +29,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Geolocation" Version="1.2.1" />

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -8,7 +8,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/fss-public-api.zip
+  artifact: ./bin/release/net8.0/fss-public-api.zip
 
 functions:
   fssPublicApi:

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -8,7 +8,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/net8.0/fss-public-api.zip
+  artifact: ./bin/release/fss-public-api.zip
 
 functions:
   fssPublicApi:


### PR DESCRIPTION
# What
This PR updates the serverless version to V4. A couple of packages have also been updated
# Why
To allow the API to be deployed again.