### PR TITLE
Bugfix/prod tf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              ignore: [bugfix/prod-tf, develop]
+              ignore: [master, bugfix/prod-tf]
 
       - build-and-test:
           context:
@@ -384,7 +384,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              ignore: [bugfix/prod-tf, develop]
+              ignore: [master, bugfix/prod-tf]
 
       - assume-role-development:
           context: api-assume-role-development-context
@@ -392,21 +392,21 @@ workflows:
             - build-and-test
           filters:
             branches:
-              ignore: [bugfix/prod-tf, develop]
+              ignore: [master, bugfix/prod-tf]
 
       - preview-development-terraform:
           requires:
             - assume-role-development
           filters:
             branches:
-              ignore: [bugfix/prod-tf, develop]
+              ignore: [master, bugfix/prod-tf]
 
   check-and-deploy-development:
     jobs:
       - check-code-formatting:
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - build-and-test:
           context:
@@ -415,7 +415,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - permit-development-release:
           type: approval
@@ -423,7 +423,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - assume-role-development:
           context: api-assume-role-development-context
@@ -431,7 +431,7 @@ workflows:
             - permit-development-release
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - deploy-to-development:
           context:
@@ -442,14 +442,14 @@ workflows:
             - assume-role-development
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
   check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting:
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - build-and-test:
           context:
@@ -458,7 +458,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - permit-staging-release:
           type: approval
@@ -466,7 +466,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - assume-role-staging:
           context: api-assume-role-staging-context
@@ -474,7 +474,7 @@ workflows:
             - permit-staging-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - deploy-to-staging:
           context:
@@ -485,7 +485,7 @@ workflows:
             - assume-role-staging
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - permit-production-release:
           type: approval
@@ -493,7 +493,7 @@ workflows:
             - deploy-to-staging
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - assume-role-production:
           context: api-assume-role-production-context
@@ -501,7 +501,7 @@ workflows:
             - permit-production-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - deploy-to-production:
           context:
@@ -512,7 +512,7 @@ workflows:
             - assume-role-production
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
   terraform-release:
     jobs:
@@ -520,14 +520,14 @@ workflows:
           context: api-assume-role-development-context
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - preview-development-terraform:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - permit-terraform-development-release:
           type: approval
@@ -535,27 +535,27 @@ workflows:
             - preview-development-terraform
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - deploy-development-terraform:
           requires:
             - permit-terraform-development-release
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       - assume-role-staging:
           context: api-assume-role-staging-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - preview-staging-terraform:
           requires:
             - assume-role-staging
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - permit-terraform-staging-release:
           type: approval
@@ -563,27 +563,27 @@ workflows:
             - preview-staging-terraform
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - deploy-staging-terraform:
           requires:
             - permit-terraform-staging-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - assume-role-production:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - preview-production-terraform:
           requires:
             - assume-role-production
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - permit-terraform-production-release:
           type: approval
@@ -591,14 +591,14 @@ workflows:
             - preview-production-terraform
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       - deploy-production-terraform:
           requires:
             - permit-terraform-production-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
   database-migration:
     jobs:
@@ -607,72 +607,72 @@ workflows:
           context: api-assume-role-development-context
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
       - preview-migrations-development:
           context: central-parameter-store-context
           requires: [assume-role-development]
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
       - permit-migration-development:
           type: approval
           requires: [preview-migrations-development]
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
       - migrate-database-development:
           context: central-parameter-store-context
           requires: [permit-migration-development]
           filters:
             branches:
-              only: [develop]
+              only: [bugfix/prod-tf]
 
       # Staging migrations
       - assume-role-staging:
           context: api-assume-role-staging-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - preview-migrations-staging:
           context: central-parameter-store-context
           requires: [assume-role-staging]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - permit-migration-staging:
           type: approval
           requires: [preview-migrations-staging]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - migrate-database-staging:
           context: central-parameter-store-context
           requires: [permit-migration-staging]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
 
       # Production migrations
       - assume-role-production:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - preview-migrations-production:
           context: central-parameter-store-context
           requires: [assume-role-production]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - permit-migration-production:
           type: approval
           requires: [preview-migrations-production]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]
       - migrate-database-production:
           context: central-parameter-store-context
           requires: [permit-migration-production]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [master]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              ignore: [master, develop]
+              ignore: [bugfix/prod-tf, develop]
 
       - build-and-test:
           context:
@@ -384,7 +384,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              ignore: [master, develop]
+              ignore: [bugfix/prod-tf, develop]
 
       - assume-role-development:
           context: api-assume-role-development-context
@@ -392,14 +392,14 @@ workflows:
             - build-and-test
           filters:
             branches:
-              ignore: [master, develop]
+              ignore: [bugfix/prod-tf, develop]
 
       - preview-development-terraform:
           requires:
             - assume-role-development
           filters:
             branches:
-              ignore: [master, develop]
+              ignore: [bugfix/prod-tf, develop]
 
   check-and-deploy-development:
     jobs:
@@ -449,7 +449,7 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - build-and-test:
           context:
@@ -458,7 +458,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - permit-staging-release:
           type: approval
@@ -466,7 +466,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - assume-role-staging:
           context: api-assume-role-staging-context
@@ -474,7 +474,7 @@ workflows:
             - permit-staging-release
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - deploy-to-staging:
           context:
@@ -485,7 +485,7 @@ workflows:
             - assume-role-staging
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - permit-production-release:
           type: approval
@@ -493,7 +493,7 @@ workflows:
             - deploy-to-staging
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - assume-role-production:
           context: api-assume-role-production-context
@@ -501,7 +501,7 @@ workflows:
             - permit-production-release
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - deploy-to-production:
           context:
@@ -512,7 +512,7 @@ workflows:
             - assume-role-production
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
   terraform-release:
     jobs:
@@ -548,14 +548,14 @@ workflows:
           context: api-assume-role-staging-context
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - preview-staging-terraform:
           requires:
             - assume-role-staging
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - permit-terraform-staging-release:
           type: approval
@@ -563,14 +563,14 @@ workflows:
             - preview-staging-terraform
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - deploy-staging-terraform:
           requires:
             - permit-terraform-staging-release
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - assume-role-production:
           context: api-assume-role-production-context
@@ -632,47 +632,47 @@ workflows:
           context: api-assume-role-staging-context
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - preview-migrations-staging:
           context: central-parameter-store-context
           requires: [assume-role-staging]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - permit-migration-staging:
           type: approval
           requires: [preview-migrations-staging]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - migrate-database-staging:
           context: central-parameter-store-context
           requires: [permit-migration-staging]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       # Production migrations
       - assume-role-production:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - preview-migrations-production:
           context: central-parameter-store-context
           requires: [assume-role-production]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - permit-migration-production:
           type: approval
           requires: [preview-migrations-production]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
       - migrate-database-production:
           context: central-parameter-store-context
           requires: [permit-migration-production]
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              ignore: [master, bugfix/prod-tf]
+              ignore: [master, develop]
 
       - build-and-test:
           context:
@@ -384,7 +384,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              ignore: [master, bugfix/prod-tf]
+              ignore: [master, develop]
 
       - assume-role-development:
           context: api-assume-role-development-context
@@ -392,21 +392,21 @@ workflows:
             - build-and-test
           filters:
             branches:
-              ignore: [master, bugfix/prod-tf]
+              ignore: [master, develop]
 
       - preview-development-terraform:
           requires:
             - assume-role-development
           filters:
             branches:
-              ignore: [master, bugfix/prod-tf]
+              ignore: [master, develop]
 
   check-and-deploy-development:
     jobs:
       - check-code-formatting:
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - build-and-test:
           context:
@@ -415,7 +415,7 @@ workflows:
           requires: [check-code-formatting]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - permit-development-release:
           type: approval
@@ -423,7 +423,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - assume-role-development:
           context: api-assume-role-development-context
@@ -431,7 +431,7 @@ workflows:
             - permit-development-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - deploy-to-development:
           context:
@@ -442,7 +442,7 @@ workflows:
             - assume-role-development
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
   check-and-deploy-staging-and-production:
     jobs:
@@ -520,14 +520,14 @@ workflows:
           context: api-assume-role-development-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - preview-development-terraform:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - permit-terraform-development-release:
           type: approval
@@ -535,14 +535,14 @@ workflows:
             - preview-development-terraform
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - deploy-development-terraform:
           requires:
             - permit-terraform-development-release
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       - assume-role-staging:
           context: api-assume-role-staging-context
@@ -607,25 +607,25 @@ workflows:
           context: api-assume-role-development-context
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
       - preview-migrations-development:
           context: central-parameter-store-context
           requires: [assume-role-development]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
       - permit-migration-development:
           type: approval
           requires: [preview-migrations-development]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
       - migrate-database-development:
           context: central-parameter-store-context
           requires: [permit-migration-development]
           filters:
             branches:
-              only: [bugfix/prod-tf]
+              only: [develop]
 
       # Staging migrations
       - assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,14 +576,14 @@ workflows:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - preview-production-terraform:
           requires:
             - assume-role-production
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - permit-terraform-production-release:
           type: approval
@@ -591,14 +591,14 @@ workflows:
             - preview-production-terraform
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
       - deploy-production-terraform:
           requires:
             - permit-terraform-production-release
           filters:
             branches:
-              only: [master]
+              only: [bugfix/prod-tf]
 
   database-migration:
     jobs:

--- a/LBHFSSPublicAPI.Tests/V1/Controllers/ImagesControllerTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Controllers/ImagesControllerTests.cs
@@ -8,6 +8,7 @@ using Amazon.S3.Model;
 using FluentAssertions;
 using LBHFSSPublicAPI.V1.Controllers;
 using LBHFSSPublicAPI.V1.Infrastructure;
+using LBHFSSPublicAPI.Tests.TestHelpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,7 +18,7 @@ using NUnit.Framework;
 namespace LBHFSSPublicAPI.Tests.V1.Controllers
 {
     [TestFixture]
-    public class ImagesControllerTests
+    public class ImagesControllerTests : DatabaseTests
     {
         private Mock<IAmazonS3> _s3;
         private ImagesController _controller;
@@ -27,7 +28,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         {
             _s3 = new Mock<IAmazonS3>();
             var options = new ImageStoreOptions("fss-imagestore-test");
-            _controller = new ImagesController(_s3.Object, options, NullLogger<ImagesController>.Instance)
+            _controller = new ImagesController(_s3.Object, options, DatabaseContext, NullLogger<ImagesController>.Instance)
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
             };
@@ -37,10 +38,11 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public async Task GetImage_ValidMedium_ReturnsJpegFile()
         {
             var stream = new MemoryStream(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 });
+            var serviceId = AddServiceWithImage("https://assets.example.com/images/99-original.jpg;https://assets.example.com/images/99-medium.jpg");
             _s3.Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetObjectResponse { ResponseStream = stream });
 
-            var result = await _controller.GetImage(99, "medium") as FileStreamResult;
+            var result = await _controller.GetImage(serviceId, "medium") as FileStreamResult;
 
             result.Should().NotBeNull();
             result!.ContentType.Should().Be("image/jpeg");
@@ -54,14 +56,16 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public async Task GetImage_ValidOriginal_UsesOriginalKey()
         {
             var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+            var serviceId = AddServiceWithImage("https://assets.example.com/images/7-original.png;https://assets.example.com/images/7-medium.png");
             _s3.Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetObjectResponse { ResponseStream = stream });
 
-            var result = await _controller.GetImage(7, "original");
+            var result = await _controller.GetImage(serviceId, "original") as FileStreamResult;
 
-            result.Should().BeOfType<FileStreamResult>();
+            result.Should().NotBeNull();
+            result!.ContentType.Should().Be("image/png");
             _s3.Verify(x => x.GetObjectAsync(
-                It.Is<GetObjectRequest>(r => r.Key == "images/7-original.jpg"),
+                It.Is<GetObjectRequest>(r => r.Key == "images/7-original.png"),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -69,13 +73,14 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public async Task GetImage_SizeIsCaseInsensitive()
         {
             var stream = new MemoryStream();
+            var serviceId = AddServiceWithImage("https://assets.example.com/images/1-original.png;https://assets.example.com/images/1-medium.png");
             _s3.Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetObjectResponse { ResponseStream = stream });
 
-            await _controller.GetImage(1, "MEDIUM");
+            await _controller.GetImage(serviceId, "MEDIUM");
 
             _s3.Verify(x => x.GetObjectAsync(
-                It.Is<GetObjectRequest>(r => r.Key == "images/1-medium.jpg"),
+                It.Is<GetObjectRequest>(r => r.Key == "images/1-medium.png"),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -94,6 +99,7 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
             var controller = new ImagesController(
                 _s3.Object,
                 new ImageStoreOptions(string.Empty),
+                DatabaseContext,
                 NullLogger<ImagesController>.Instance)
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
@@ -110,10 +116,11 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         [Test]
         public async Task GetImage_S3ObjectNotFound_ReturnsNotFound()
         {
+            var serviceId = AddServiceWithImage("https://assets.example.com/images/404-original.jpg;https://assets.example.com/images/404-medium.jpg");
             _s3.Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new AmazonS3Exception("NoSuchKey") { StatusCode = HttpStatusCode.NotFound });
 
-            var result = await _controller.GetImage(404, "medium");
+            var result = await _controller.GetImage(serviceId, "medium");
 
             result.Should().BeOfType<NotFoundResult>();
         }
@@ -121,14 +128,33 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         [Test]
         public async Task GetImage_OtherS3Error_Returns502()
         {
+            var serviceId = AddServiceWithImage("https://assets.example.com/images/1-original.jpg;https://assets.example.com/images/1-medium.jpg");
             _s3.Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new AmazonS3Exception("AccessDenied") { StatusCode = HttpStatusCode.Forbidden });
 
-            var result = await _controller.GetImage(1, "medium");
+            var result = await _controller.GetImage(serviceId, "medium");
 
             var status = result as ObjectResult;
             status.Should().NotBeNull();
             status!.StatusCode.Should().Be(502);
+        }
+
+        [Test]
+        public async Task GetImage_ServiceHasNoImage_ReturnsNotFound()
+        {
+            var result = await _controller.GetImage(999999, "medium");
+
+            result.Should().BeOfType<NotFoundResult>();
+            _s3.Verify(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        private int AddServiceWithImage(string imageUrl)
+        {
+            var service = EntityHelpers.CreateService();
+            service.Image.Url = imageUrl;
+            DatabaseContext.Services.Add(service);
+            DatabaseContext.SaveChanges();
+            return service.Id;
         }
     }
 }

--- a/LBHFSSPublicAPI/V1/Controllers/ImagesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/ImagesController.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon.S3;
 using LBHFSSPublicAPI.V1.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace LBHFSSPublicAPI.V1.Controllers
@@ -14,18 +16,20 @@ namespace LBHFSSPublicAPI.V1.Controllers
     {
         private readonly IAmazonS3 _s3Client;
         private readonly ImageStoreOptions _options;
+        private readonly DatabaseContext _databaseContext;
         private readonly ILogger<ImagesController> _logger;
 
-        public ImagesController(IAmazonS3 s3Client, ImageStoreOptions options, ILogger<ImagesController> logger)
+        public ImagesController(IAmazonS3 s3Client, ImageStoreOptions options, DatabaseContext databaseContext, ILogger<ImagesController> logger)
         {
             _s3Client = s3Client;
             _options = options;
+            _databaseContext = databaseContext;
             _logger = logger;
         }
 
         /// <summary>
         /// Streams an image from the private S3 imagestore. Size can be "medium" or "original".
-        /// S3 key format: images/{id}-{size}.jpg
+        /// Uses the image key stored against the service so original file extensions are preserved.
         /// </summary>
         [HttpGet]
         [Route("{id}/{size}")]
@@ -38,7 +42,9 @@ namespace LBHFSSPublicAPI.V1.Controllers
                 !string.Equals(size, "original", StringComparison.OrdinalIgnoreCase))
                 return BadRequest("Size must be 'medium' or 'original'.");
 
-            var key = $"images/{id}-{size.ToLowerInvariant()}.jpg";
+            var key = await GetImageKey(id, size).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(key))
+                return NotFound();
 
             try
             {
@@ -54,7 +60,7 @@ namespace LBHFSSPublicAPI.V1.Controllers
                 var stream = new MemoryStream();
                 await response.ResponseStream.CopyToAsync(stream);
                 stream.Position = 0;
-                return File(stream, "image/jpeg", enableRangeProcessing: true);
+                return File(stream, GetContentType(key), enableRangeProcessing: true);
             }
             catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -74,6 +80,46 @@ namespace LBHFSSPublicAPI.V1.Controllers
                 Response.Headers["X-Error-Message"] = msg;
                 return StatusCode(500, msg);
             }
+        }
+
+        private async Task<string> GetImageKey(int serviceId, string size)
+        {
+            var service = await _databaseContext.Services
+                .Include(x => x.Image)
+                .FirstOrDefaultAsync(x => x.Id == serviceId)
+                .ConfigureAwait(false);
+
+            var imageUrls = service?.Image?.Url?.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            if (imageUrls == null || imageUrls.Length == 0)
+                return null;
+
+            var imageUrl = string.Equals(size, "medium", StringComparison.OrdinalIgnoreCase) && imageUrls.Length > 1
+                ? imageUrls[1]
+                : imageUrls[0];
+
+            return ToS3Key(imageUrl);
+        }
+
+        private static string ToS3Key(string imageUrl)
+        {
+            if (string.IsNullOrWhiteSpace(imageUrl))
+                return null;
+
+            if (Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri))
+                return Uri.UnescapeDataString(uri.AbsolutePath.TrimStart('/'));
+
+            return imageUrl.Trim().TrimStart('/');
+        }
+
+        private static string GetContentType(string key)
+        {
+            return Path.GetExtension(key).ToLowerInvariant() switch
+            {
+                ".png" => "image/png",
+                ".gif" => "image/gif",
+                ".webp" => "image/webp",
+                _ => "image/jpeg"
+            };
         }
     }
 }

--- a/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
@@ -24,12 +24,23 @@ namespace LBHFSSPublicAPI.V1.Controllers
         [Route("{id}")]
         public IActionResult GetService([FromRoute] GetServiceByIdRequest requestParams) //if user doens't input anything, then it will be 0 by default!!!
         {
-            var usecaseResult = _servicesUseCase.ExecuteGet(requestParams);
+            try
+            {
+                var usecaseResult = _servicesUseCase.ExecuteGet(requestParams);
 
-            if (usecaseResult != null)
-                return Ok(usecaseResult);
+                if (usecaseResult != null)
+                    return Ok(usecaseResult);
 
-            return NotFound(new ErrorResponse($"Service with an Id: {requestParams.Id} was not found."));
+                return NotFound(new ErrorResponse($"Service with an Id: {requestParams.Id} was not found."));
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message));
+            }
         }
 
         [HttpGet]

--- a/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/ServicesController.cs
@@ -33,13 +33,9 @@ namespace LBHFSSPublicAPI.V1.Controllers
 
                 return NotFound(new ErrorResponse($"Service with an Id: {requestParams.Id} was not found."));
             }
-            catch (Exception ex) when (ex.InnerException != null)
+            catch (Exception)
             {
-                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new ErrorResponse(ex.Message));
+                return StatusCode(500, new ErrorResponse("There was a problem getting the service."));
             }
         }
 
@@ -51,13 +47,9 @@ namespace LBHFSSPublicAPI.V1.Controllers
                 var usecaseResult = _servicesUseCase.ExecuteGet(requestParams);
                 return Ok(usecaseResult);
             }
-            catch (Exception ex) when (ex.InnerException != null)
+            catch (Exception)
             {
-                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new ErrorResponse(ex.Message));
+                return StatusCode(500, new ErrorResponse("There was a problem searching services."));
             }
         }
     }

--- a/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
@@ -26,13 +26,9 @@ namespace LBHFSSPublicAPI.V1.Controllers
                 var result = _taxonomiesUseCase.ExecuteGet(vocabulary);
                 return Ok(result);
             }
-            catch (Exception ex) when (ex.InnerException != null)
+            catch (Exception)
             {
-                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new ErrorResponse(ex.Message));
+                return StatusCode(500, new ErrorResponse("There was a problem getting taxonomies."));
             }
         }
 
@@ -49,13 +45,9 @@ namespace LBHFSSPublicAPI.V1.Controllers
 
                 return NotFound(new ErrorResponse($"Taxonomy with an Id: {id} was not found."));
             }
-            catch (Exception ex) when (ex.InnerException != null)
+            catch (Exception)
             {
-                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, new ErrorResponse(ex.Message));
+                return StatusCode(500, new ErrorResponse("There was a problem getting the taxonomy."));
             }
         }
     }

--- a/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
+++ b/LBHFSSPublicAPI/V1/Controllers/TaxonomiesController.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
+using System;
 using LBHFSSPublicAPI.V1.Boundary;
-using LBHFSSPublicAPI.V1.UseCase;
 using LBHFSSPublicAPI.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,20 +21,42 @@ namespace LBHFSSPublicAPI.V1.Controllers
         //[ProducesResponseType(typeof(Dictionary<string, bool>), 200)]
         public IActionResult GetTaxonomies([FromQuery] string vocabulary = null)
         {
-            var result = _taxonomiesUseCase.ExecuteGet(vocabulary);
-            return Ok(result);
+            try
+            {
+                var result = _taxonomiesUseCase.ExecuteGet(vocabulary);
+                return Ok(result);
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message));
+            }
         }
 
         [HttpGet]
         [Route("{id}")]
         public IActionResult GetTaxonomy([FromRoute] int id) //if user doens't input anything, then it will be 0 by default!!!
         {
-            var usecaseResult = _taxonomiesUseCase.ExecuteGet(id);
+            try
+            {
+                var usecaseResult = _taxonomiesUseCase.ExecuteGet(id);
 
-            if (usecaseResult != null)
-                return Ok(usecaseResult);
+                if (usecaseResult != null)
+                    return Ok(usecaseResult);
 
-            return NotFound(new ErrorResponse($"Taxonomy with an Id: {id} was not found."));
+                return NotFound(new ErrorResponse($"Taxonomy with an Id: {id} was not found."));
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message, ex.InnerException.Message));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new ErrorResponse(ex.Message));
+            }
         }
     }
 }

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
@@ -16,6 +16,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
             _apiBaseUrl = options.ApiBaseUrl;
             _apiKey = options.ApiKey;
             _apiToken = options.ApiToken;
+            _httpClient.Timeout = TimeSpan.FromSeconds(5);
         }
 
         public AddressesAPIContextResponse GetAddressesRequest(string postcode) // asc Block for now.
@@ -23,7 +24,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
             // Build the request
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
-            var fullUrlString = $"{_apiBaseUrl}addresses?PostCode={postcode}&Gazetteer=Both&Format=Detailed"; //Gazeteer Both? or Local?
+            var fullUrlString = $"{_apiBaseUrl}addresses?PostCode={Uri.EscapeDataString(postcode)}&Gazetteer=Both&Format=Detailed"; //Gazeteer Both? or Local?
             request.RequestUri = new Uri(fullUrlString);
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiToken);
 

--- a/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/AddressesAPIContext.cs
@@ -24,7 +24,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
             // Build the request
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
-            var fullUrlString = $"{_apiBaseUrl}addresses?PostCode={Uri.EscapeDataString(postcode)}&Gazetteer=Both&Format=Detailed"; //Gazeteer Both? or Local?
+            var fullUrlString = $"{_apiBaseUrl}addresses?PostCode={Uri.EscapeDataString(postcode)}&Gazetteer=Both&Format=Detailed";
             request.RequestUri = new Uri(fullUrlString);
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiToken);
 

--- a/LBHFSSPublicAPI/V1/Infrastructure/ImageStoreOptions.cs
+++ b/LBHFSSPublicAPI/V1/Infrastructure/ImageStoreOptions.cs
@@ -6,7 +6,7 @@ namespace LBHFSSPublicAPI.V1.Infrastructure
 
         public ImageStoreOptions(string bucketName)
         {
-            BucketName = bucketName;
+            BucketName = bucketName?.Trim() ?? string.Empty;
         }
     }
 }

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -31,6 +31,10 @@ functions:
       FSS_PUBLIC_API_BASE_URL: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/${self:provider.stage}apis/${self:provider.stage}-apis/${self:provider.stage}apis/fss-public-api-base-url}
     events:
       - http:
+          path: /api/v1/images/{proxy+}
+          method: GET
+          private: false
+      - http:
           path: /{proxy+}
           method: ANY
           private: true

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -72,15 +72,19 @@ resources:
                   Action:
                     - s3:ListBucket
                   Resource:
-                    - "arn:aws:s3:::${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/${self:provider.stage}apis/fss-common-api-${self:provider.stage}/fss-common-api/images-bucket-name}"
+                    - "arn:aws:s3:::${self:custom.imageStoreBucket.${self:provider.stage}}"
                 - Effect: Allow
                   Action:
                     - s3:PutObject
                     - s3:GetObject
                     - s3:DeleteObject
                   Resource:
-                    - "arn:aws:s3:::${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/${self:provider.stage}apis/fss-common-api-${self:provider.stage}/fss-common-api/images-bucket-name}/*"
+                    - "arn:aws:s3:::${self:custom.imageStoreBucket.${self:provider.stage}}/*"
 custom:
+  imageStoreBucket:
+    development: fss-imagestore-development
+    staging: fss-imagestore-staging
+    production: fss-imagestore-live
   vpc:
     development:
       securityGroupIds:

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -72,14 +72,14 @@ resources:
                   Action:
                     - s3:ListBucket
                   Resource:
-                    - "arn:aws:s3:::fss-imagestore-${self:provider.stage}"
+                    - "arn:aws:s3:::${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/${self:provider.stage}apis/fss-common-api-${self:provider.stage}/fss-common-api/images-bucket-name}"
                 - Effect: Allow
                   Action:
                     - s3:PutObject
                     - s3:GetObject
                     - s3:DeleteObject
                   Resource:
-                    - "arn:aws:s3:::fss-imagestore-${self:provider.stage}/*"
+                    - "arn:aws:s3:::${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/${self:provider.stage}apis/fss-common-api-${self:provider.stage}/fss-common-api/images-bucket-name}/*"
 custom:
   vpc:
     development:

--- a/data.tf
+++ b/data.tf
@@ -38,3 +38,11 @@ data "aws_ssm_parameter" "postgres_port" {
 data "aws_ssm_parameter" "postgres_database" {
   name = "arn:aws:ssm:eu-west-2:${local.current_config.centralised_parameter_store_account_id}:parameter/${local.environment}apis/fss-public-api-${local.environment}/fss-public-api/postgres-database"
 }
+
+data "aws_ssm_parameter" "jump_box_instance_name" {
+  name = "arn:aws:ssm:eu-west-2:${local.current_config.centralised_parameter_store_account_id}:parameter/${local.environment}apis/${local.environment}-apis/${local.environment}apis/jump-box-instance-name"
+}
+
+data "aws_instance" "jump_box" {
+  instance_id = data.aws_ssm_parameter.jump_box_instance_name.value
+}

--- a/locals.tf
+++ b/locals.tf
@@ -19,6 +19,7 @@ locals {
       deletion_protection                    = false
       maintenance_window                     = "sun:10:00-sun:10:30"
       lambda_security_group_id               = "sg-07aa5b4bfe5431d73"
+      portal_lambda_security_group_id        = "sg-033babc9f5ce30345"
       centralised_parameter_store_account_id = "115283375626"
       additional_tags = {
         BackupPolicy = "Dev"
@@ -36,6 +37,7 @@ locals {
       deletion_protection                    = true
       maintenance_window                     = "sun:10:00-sun:10:30"
       lambda_security_group_id               = "sg-00be85a006bff97e8"
+      portal_lambda_security_group_id        = "sg-04c73000bf97eae7e"
       centralised_parameter_store_account_id = "469511945406"
       additional_tags = {
         BackupPolicy = "Stg"
@@ -53,6 +55,7 @@ locals {
       deletion_protection                    = false
       maintenance_window                     = "sun:10:00-sun:10:30"
       lambda_security_group_id               = "sg-038eb450496ec5548"
+      portal_lambda_security_group_id        = "sg-060458cddaaa2742a"
       centralised_parameter_store_account_id = "918025132036"
       additional_tags = {
         BackupPolicy = "Prod"

--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,7 @@ locals {
       multi_az                               = false
       deletion_protection                    = false
       maintenance_window                     = "sun:10:00-sun:10:30"
+      lambda_security_group_id               = "sg-07aa5b4bfe5431d73"
       centralised_parameter_store_account_id = "115283375626"
       additional_tags = {
         BackupPolicy = "Dev"
@@ -34,6 +35,7 @@ locals {
       multi_az                               = false
       deletion_protection                    = true
       maintenance_window                     = "sun:10:00-sun:10:30"
+      lambda_security_group_id               = "sg-00be85a006bff97e8"
       centralised_parameter_store_account_id = "469511945406"
       additional_tags = {
         BackupPolicy = "Stg"
@@ -50,6 +52,7 @@ locals {
       multi_az                               = true
       deletion_protection                    = false
       maintenance_window                     = "sun:10:00-sun:10:30"
+      lambda_security_group_id               = "sg-038eb450496ec5548"
       centralised_parameter_store_account_id = "918025132036"
       additional_tags = {
         BackupPolicy = "Prod"

--- a/module.tf
+++ b/module.tf
@@ -34,6 +34,16 @@ resource "aws_security_group_rule" "postgres_ingress_from_lambda" {
   source_security_group_id = local.current_config.lambda_security_group_id
 }
 
+resource "aws_security_group_rule" "postgres_ingress_from_portal_lambda" {
+  type                     = "ingress"
+  description              = "Allow portal API Lambda to access PostgreSQL"
+  from_port                = data.aws_ssm_parameter.postgres_port.value
+  to_port                  = data.aws_ssm_parameter.postgres_port.value
+  protocol                 = "tcp"
+  security_group_id        = module.postgres_db.db_security_group_id
+  source_security_group_id = local.current_config.portal_lambda_security_group_id
+}
+
 resource "aws_security_group_rule" "postgres_ingress_from_jump_box" {
   for_each = toset(data.aws_instance.jump_box.vpc_security_group_ids)
 

--- a/module.tf
+++ b/module.tf
@@ -23,3 +23,25 @@ module "postgres_db" {
   copy_tags_to_snapshot   = true
   additional_tags         = lookup(local.current_config, "additional_tags", {})
 }
+
+resource "aws_security_group_rule" "postgres_ingress_from_lambda" {
+  type                     = "ingress"
+  description              = "Allow public API Lambda to access PostgreSQL"
+  from_port                = data.aws_ssm_parameter.postgres_port.value
+  to_port                  = data.aws_ssm_parameter.postgres_port.value
+  protocol                 = "tcp"
+  security_group_id        = module.postgres_db.db_security_group_id
+  source_security_group_id = local.current_config.lambda_security_group_id
+}
+
+resource "aws_security_group_rule" "postgres_ingress_from_jump_box" {
+  for_each = toset(data.aws_instance.jump_box.vpc_security_group_ids)
+
+  type                     = "ingress"
+  description              = "Allow SSM jump box to access PostgreSQL for migrations"
+  from_port                = data.aws_ssm_parameter.postgres_port.value
+  to_port                  = data.aws_ssm_parameter.postgres_port.value
+  protocol                 = "tcp"
+  security_group_id        = module.postgres_db.db_security_group_id
+  source_security_group_id = each.value
+}


### PR DESCRIPTION
What
--
This PR adds the required database ingress rules so the public API Lambda, portal API Lambda, and SSM jump box (for DB migrations) can reach the PostgreSQL instance.

It also updates image handling so the API retrieves images from the private image store using the image URLs stored against each service.

## Key Changes
- Adds Terraform security group ingress for:
  - public API Lambda to PostgreSQL
  - portal API Lambda to PostgreSQL
  - SSM jump box to PostgreSQL for migrations
- Adds lookup of the jump box instance via SSM.
- Updates Serverless config to expose `/api/v1/images/{proxy+}` publicly.
- Corrects S3 bucket naming for the image store, including production using `fss-imagestore-live`.
- Updates image retrieval to:
  - read the service image URL from the database
  - preserve the original file extension
  - support JPEG, PNG, GIF, and WebP content types
  - return `404` when the service has no image
- Trims image bucket config values to avoid whitespace-related failures - this was part of debugging but worth keeping.
- URL-encodes postcode values before calling the Addresses API and adds a 5s timeout - again part of debugging but valuable to keep
- Adds error handling around service and taxonomy lookups so unexpected backend errors return structured `500` responses instead of unhandled.
