### PR TITLE
Upgrade API from .NET 8 to .NET 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
       - image: hashicorp/terraform:1.14
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:8.0
+      - image: mcr.microsoft.com/dotnet/sdk:10.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/LBHFSSPublicAPI.Tests/Dockerfile
+++ b/LBHFSSPublicAPI.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
+++ b/LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -12,23 +12,23 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.11.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
         <PackageReference Include="Bogus" Version="25.0.4" />
         <PackageReference Include="Moq" Version="4.10.1" />
-        <PackageReference Include="nunit" Version="3.11.0" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+        <PackageReference Include="nunit" Version="3.14.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
         <PackageReference Include="Geolocation" Version="1.2.1" />
     </ItemGroup>
 

--- a/LBHFSSPublicAPI.Tests/V1/Controllers/ServicesControllerTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/Controllers/ServicesControllerTests.cs
@@ -98,10 +98,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public void ServiceControllerSearchServiceMethodHandlesSimpleExceptionsByReturningCustomErrorObject()
         {
             // arrange
-            (var randomExpectedException, var expectedExceptionMessages) =
+            (var randomExpectedException, _) =
                 GenerateExceptionAndCorrespondinExceptionMessages(ExceptionType.SimpleException);
-
-            var expectedExceptionMessage = expectedExceptionMessages[0];
 
             _mockUseCase.Setup(u => u.ExecuteGet(It.IsAny<SearchServicesRequest>())).Throws(randomExpectedException);
 
@@ -114,10 +112,9 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
             var actualExceptionMessage = returnedContent.Errors[0];
 
             returnedContent.Should().NotBeNull();
-            returnedContent.Errors.Count.Should().Be(expectedExceptionMessages.Count);
             returnedContent.Errors.Count.Should().Be(1);
 
-            actualExceptionMessage.Should().Be(expectedExceptionMessage);
+            actualExceptionMessage.Should().Be("There was a problem searching services.");
         }
 
 
@@ -125,11 +122,8 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
         public void ServiceControllerSearchServiceMethodHandlesNestedExceptionsByReturningCustomErrorObject()
         {
             // arrange
-            (var randomExpectedException, var expectedExceptionMessages) =
+            (var randomExpectedException, _) =
                 GenerateExceptionAndCorrespondinExceptionMessages(ExceptionType.InnerException);
-
-            var expectedExceptionMessage = expectedExceptionMessages[0];
-            var expectedInnerExceptionMessage = expectedExceptionMessages[1];
 
             _mockUseCase.Setup(u => u.ExecuteGet(It.IsAny<SearchServicesRequest>())).Throws(randomExpectedException);
 
@@ -140,14 +134,11 @@ namespace LBHFSSPublicAPI.Tests.V1.Controllers
             var controllerObjectResult = controllerResponse as ObjectResult;
             var returnedContent = controllerObjectResult.Value as ErrorResponse;
             var actualExceptionMessage = returnedContent.Errors[0];
-            var actualInnerExceptionMessage = returnedContent.Errors[1];
 
             returnedContent.Should().NotBeNull();
-            returnedContent.Errors.Count.Should().Be(expectedExceptionMessages.Count);
-            returnedContent.Errors.Count.Should().Be(2);
+            returnedContent.Errors.Count.Should().Be(1);
 
-            actualExceptionMessage.Should().Be(expectedExceptionMessage);
-            actualInnerExceptionMessage.Should().Be(expectedInnerExceptionMessage);
+            actualExceptionMessage.Should().Be("There was a problem searching services.");
         }
 
         #endregion

--- a/LBHFSSPublicAPI.Tests/V1/UseCase/DbHealthCheckUseCaseTests.cs
+++ b/LBHFSSPublicAPI.Tests/V1/UseCase/DbHealthCheckUseCaseTests.cs
@@ -1,8 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using LBHFSSPublicAPI.V1.UseCase;
 using Bogus;
 using FluentAssertions;
-using Microsoft.Extensions.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Moq;
 using NUnit.Framework;
 
@@ -12,7 +14,7 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
     public class DbHealthCheckUseCaseTests
     {
 
-        private Mock<IHealthCheckService> _mockHealthCheckService;
+        private Mock<HealthCheckService> _mockHealthCheckService;
         private DbHealthCheckUseCase _classUnderTest;
 
         private readonly Faker _faker = new Faker();
@@ -23,14 +25,17 @@ namespace LBHFSSPublicAPI.Tests.V1.UseCase
         {
             _description = _faker.Random.Words();
 
-            _mockHealthCheckService = new Mock<IHealthCheckService>();
-            CompositeHealthCheckResult compositeHealthCheckResult = new CompositeHealthCheckResult(CheckStatus.Healthy);
-            compositeHealthCheckResult.Add("test", CheckStatus.Healthy, _description);
-
+            _mockHealthCheckService = new Mock<HealthCheckService>();
+            var healthReport = new HealthReport(
+                new Dictionary<string, HealthReportEntry>
+                {
+                    ["test"] = new HealthReportEntry(HealthStatus.Healthy, _description, TimeSpan.Zero, exception: null, data: null)
+                },
+                TimeSpan.Zero);
 
             _mockHealthCheckService.Setup(s =>
-                    s.CheckHealthAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(compositeHealthCheckResult);
+                    s.CheckHealthAsync(It.IsAny<Func<HealthCheckRegistration, bool>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(healthReport);
 
             _classUnderTest = new DbHealthCheckUseCase(_mockHealthCheckService.Object);
         }

--- a/LBHFSSPublicAPI/Dockerfile
+++ b/LBHFSSPublicAPI/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 WORKDIR /app
 

--- a/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
+++ b/LBHFSSPublicAPI/LBHFSSPublicAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,30 +12,27 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="5.3.1" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.2.0" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
-    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.2.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageReference Include="Geolocation" Version="1.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LBHFSSPublicAPI/Startup.cs
+++ b/LBHFSSPublicAPI/Startup.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reflection;
 using Amazon;
 using Amazon.S3;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using LBHFSSPublicAPI.V1.Gateways;
 using LBHFSSPublicAPI.V1.Gateways.Interfaces;
 using LBHFSSPublicAPI.V1.Infrastructure;
@@ -13,14 +15,11 @@ using LBHFSSPublicAPI.V1.UseCase.Interfaces;
 using LBHFSSPublicAPI.Versioning;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 
@@ -40,20 +39,16 @@ namespace LBHFSSPublicAPI
         // This method gets called by the runtime. Use this method to add services to the container.
         public static void ConfigureServices(IServiceCollection services)
         {
-            services
-            .AddMvc(setupAction =>
-            {
-                setupAction.EnableEndpointRouting = false;
-            })
-            .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddControllers();
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);
                 o.AssumeDefaultVersionWhenUnspecified = true;// assume that the caller wants the default version if they don't specify
                 o.ApiVersionReader = new UrlSegmentApiVersionReader();// read the version number from the url segment header)
-            });
+            })
+            .AddMvc()
+            .AddApiExplorer();
             services.AddCors();
-            services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();
 
             services.AddSwaggerGen(c =>
             {
@@ -66,16 +61,10 @@ namespace LBHFSSPublicAPI
         Type = SecuritySchemeType.ApiKey
     });
 
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement
-            {
-{
-new OpenApiSecurityScheme
-{
-Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Token" }
-},
-new List<string>()
-}
-            });
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+                {
+                    [new OpenApiSecuritySchemeReference("Token", document)] = []
+                });
 
                 //Looks at the APIVersionAttribute [ApiVersion("x")] on controllers and decides whether or not
                 //to include it in that version of the swagger document

--- a/LBHFSSPublicAPI/V1/UseCase/DbHealthCheckUseCase.cs
+++ b/LBHFSSPublicAPI/V1/UseCase/DbHealthCheckUseCase.cs
@@ -1,13 +1,14 @@
+using System.Linq;
 using LBHFSSPublicAPI.V1.Boundary;
-using Microsoft.Extensions.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace LBHFSSPublicAPI.V1.UseCase
 {
     public class DbHealthCheckUseCase
     {
-        private readonly IHealthCheckService _healthCheckService;
+        private readonly HealthCheckService _healthCheckService;
 
-        public DbHealthCheckUseCase(IHealthCheckService healthCheckService)
+        public DbHealthCheckUseCase(HealthCheckService healthCheckService)
         {
             _healthCheckService = healthCheckService;
         }
@@ -16,8 +17,9 @@ namespace LBHFSSPublicAPI.V1.UseCase
         {
             var result = _healthCheckService.CheckHealthAsync().Result;
 
-            var success = result.CheckStatus == CheckStatus.Healthy;
-            return new HealthCheckResponse(success, result.Description);
+            var success = result.Status == HealthStatus.Healthy;
+            var message = string.Join(", ", result.Entries.Select(e => $"{e.Key}: {e.Value.Description}"));
+            return new HealthCheckResponse(success, message);
         }
     }
 

--- a/LBHFSSPublicAPI/Versioning/ApiVersionDescriptionExtensions.cs
+++ b/LBHFSSPublicAPI/Versioning/ApiVersionDescriptionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Asp.Versioning.ApiExplorer;
 
 namespace LBHFSSPublicAPI.Versioning
 {
@@ -10,4 +10,3 @@ namespace LBHFSSPublicAPI.Versioning
         }
     }
 }
-

--- a/LBHFSSPublicAPI/Versioning/ApiVersionExtensions.cs
+++ b/LBHFSSPublicAPI/Versioning/ApiVersionExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
 
 namespace LBHFSSPublicAPI.Versioning
 {

--- a/LBHFSSPublicAPI/build.sh
+++ b/LBHFSSPublicAPI/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/fss-public-api.zip
+dotnet lambda package --configuration release --framework net10.0 --output-package ./bin/release/net10.0/fss-public-api.zip

--- a/LBHFSSPublicAPI/serverless.yml
+++ b/LBHFSSPublicAPI/serverless.yml
@@ -1,7 +1,7 @@
 service: fss-public-api
 provider:
   name: aws
-  runtime: dotnet8
+  runtime: dotnet10
   timeout: 15
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
@@ -14,7 +14,7 @@ provider:
       - "image/*"
 
 package:
-  artifact: ./bin/release/net8.0/fss-public-api.zip
+  artifact: ./bin/release/net10.0/fss-public-api.zip
 
 functions:
   fssPublicApi:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Find Support Services Public API is a service that exposes endpoints to allow consumers to search for support services available to Hackney residents.
 
 ### Runtime (AWS)
-- **API Gateway** → **Lambda (.NET 8)** → **RDS PostgreSQL** (in VPC private subnets).
+- **API Gateway** → **Lambda (.NET 10)** → **RDS PostgreSQL** (in VPC private subnets).
 - Lambda runs in a **VPC** with **security groups** and **private subnets** configured per environment.
 - Configuration and secrets are stored in **SSM Parameter Store**.
 
@@ -20,7 +20,7 @@ Find Support Services Public API is a service that exposes endpoints to allow co
 
 ## Stack
 
-- .NET 8 (AWS Lambda)
+- .NET 10 (AWS Lambda)
 - nUnit
 - Serverless Framework
 - Terraform


### PR DESCRIPTION
# Upgrade API from .NET 8 to .NET 10

## Summary
- Retargets the API and test projects to `net10.0` and updates EF Core, Npgsql, Lambda, Swashbuckle, and related packages for .NET 10 compatibility.
- Replaces deprecated API versioning packages with `Asp.Versioning.Mvc` / `Asp.Versioning.Mvc.ApiExplorer`, and migrates health checks off the vulnerable `Microsoft.AspNetCore.HealthChecks` 1.0 package.
- Updates Docker, CircleCI, Serverless (`dotnet10`), and build packaging paths so deploy and CI use the new runtime.

## Test plan
- [x] `dotnet build LBHFSSPublicAPI.sln`
- [x] Start local Postgres on `127.0.0.1:6543` (`testdb` / `postgres` / `mypassword`)
- [x] `dotnet test LBHFSSPublicAPI.Tests/LBHFSSPublicAPI.Tests.csproj` — expect 218 passing
- [x] Confirm CircleCI uses `mcr.microsoft.com/dotnet/sdk:10.0`
- [x] Smoke-check Swagger UI and a sample `/api/v1/...` endpoint after deploy to a non-prod stage